### PR TITLE
Extract requirements of a workflow

### DIFF
--- a/src/ewokscore/requirements.py
+++ b/src/ewokscore/requirements.py
@@ -1,0 +1,45 @@
+from typing import Any
+from pprint import pprint
+import logging
+
+from ewokscore.bindings import load_graph
+
+
+logger = logging.getLogger(__file__)
+
+
+def extract_requirements(workflow: Any):
+    imports: set[str] = set()
+    graph = load_graph(workflow)
+
+    for node_id, node in graph.graph.nodes.items():
+        task_identifier = node["task_identifier"]
+        task_type = node["task_type"]
+
+        if task_type == "class":
+            package = task_identifier.split(".")[0]
+            if package == "__main__" or "":
+                logger.warning(
+                    f"Could not extract requirements for node {node_id}: the task identifier is a relative import or a import from __main__."
+                )
+                continue
+
+            imports.add(package)
+        elif task_type.startswith("ppf"):
+            imports.add("ewoksppf")
+            logger.warning(
+                f"Requirement extraction may be incomplete for node {node_id}: {task_type} is only partially supported."
+            )
+        else:
+            logger.warning(
+                f"Could not extract requirements for node {node_id}: unsupported task type {task_type}."
+            )
+
+    return list(imports)
+
+
+if __name__ == "__main__":
+    import sys
+
+    requirements = extract_requirements(sys.argv[1])
+    pprint(requirements)

--- a/src/ewokscore/tests/test_requirements.py
+++ b/src/ewokscore/tests/test_requirements.py
@@ -1,0 +1,8 @@
+from ewokscore.requirements import extract_requirements
+from ewokscore.tests.examples.graphs import get_graph
+
+
+def test_extract_requirements():
+    workflow, _ = get_graph("demo")
+
+    assert extract_requirements(workflow) == ["ewokscore"]


### PR DESCRIPTION
***In GitLab by @loichuder on Oct 11, 2024, 17:12 GMT+2:***

For https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/issues/26

---

First, so that we are on the same page: the usecase I envision for this is the following:
1. You have a workflow you want to execute
2. You create a new venv
3. You extract requirements of the workflow (this MR) and install the said requirements in the venv (this step is not solved for me, see below).

Based on this, I tried several implementations to extract the requirements from a workflow. There are a few packages that delve into this ([findimports](https://redirect.github.com/mgedmin/findimports), [pydeps](https://redirect.github.com/thebjorn/pydeps)) which are based on [modulefinder](https://docs.python.org/3/library/modulefinder.html). 

The problem is that **_modulefinder_ does the `import`** meaning that packages needs to be installed to discover the `imports`, which defeats the purpose of our requirements extraction.

So, I settled for a "dumb" solution that simply parses the task identifiers contained in the workflow nodes. This method is not perfect and needs to be implemented specifically for each task type. So far, I only added the `class` one (our main usecase). **I'll need other workflows with other task types to continue working on this.**

---

Secondly, regardless of the implementation, it is not clear for me what we should do with the extracted requirements. Should we save them in the workflow as `requirements` fields ? But the, what if the workflow is only in memory ? Should it be the role of `ewoks install` to extract the requirements if there is no `requirements` field ?

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/250*