### PR TITLE
Raise TaskInputError when instantiating a class with missing inputs

### DIFF
--- a/ewokscore/task.py
+++ b/ewokscore/task.py
@@ -6,7 +6,7 @@ from .variable import ReadOnlyVariableContainerNamespace
 from .registration import Registered
 
 
-class TaskInputError(AssertionError):
+class TaskInputError(ValueError):
     pass
 
 
@@ -38,13 +38,13 @@ class Task(Registered, hashing.UniversalHashable, register=False):
         # Check required inputs
         missing_required = set(self._INPUT_NAMES) - set(inputs.keys())
         if missing_required:
-            raise ValueError(f"Missing inputs for {type(self)}: {missing_required}")
+            raise TaskInputError(f"Missing inputs for {type(self)}: {missing_required}")
 
         # Check required positional inputs
         nrequiredargs = self._N_REQUIRED_POSITIONAL_INPUTS
         for i in range(nrequiredargs):
             if i not in inputs and str(i) not in inputs:
-                raise ValueError(
+                raise TaskInputError(
                     f"Missing inputs for {type(self)}: positional argument #{i}"
                 )
 

--- a/ewokscore/tests/test_task.py
+++ b/ewokscore/tests/test_task.py
@@ -1,6 +1,7 @@
 import pytest
 import json
 from ewokscore.task import Task
+from ewokscore.task import TaskInputError
 from .examples.tasks.sumtask import SumTask
 
 
@@ -22,7 +23,7 @@ def test_no_public_reserved_names():
 
 
 def test_task_missing_input():
-    with pytest.raises(ValueError):
+    with pytest.raises(TaskInputError):
         SumTask()
 
 
@@ -117,5 +118,5 @@ def test_task_required_positional_inputs():
     class MyTask(Task, n_required_positional_inputs=1):
         pass
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TaskInputError):
         MyTask()


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 7, 2021, 21:15 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/6*