### PR TITLE
concatenate edge "links" attributes for multigraphs

### DIFF
--- a/ewokscore/graph.py
+++ b/ewokscore/graph.py
@@ -64,7 +64,9 @@ def flatten_multigraph(graph):
     for edge, attrs in graph.edges.items():
         key = edge[:2]
         mergedattrs = edgeattrs.setdefault(key, dict())
-        dict_merge(mergedattrs, attrs)
+        # mergedattrs["links"] and attrs["links"]
+        # could be two sequences that need to be concatenated
+        dict_merge(mergedattrs, attrs, contatenate_sequences=True)
 
     for name, attrs in graph.nodes.items():
         newgraph.add_node(name, **attrs)
@@ -169,9 +171,7 @@ class TaskGraph:
             raise TypeError(graph, type(graph))
 
         graph = flatten_multigraph(graph)
-
         subgraphs = get_subgraphs(graph)
-
         if subgraphs:
             # Extract
             edges, update_attrs = extract_subgraphs(graph, subgraphs)

--- a/ewokscore/utils.py
+++ b/ewokscore/utils.py
@@ -1,5 +1,6 @@
 import importlib
 from collections.abc import Mapping
+from collections.abc import Sequence
 
 
 def qualname(obj):
@@ -26,7 +27,9 @@ def import_method(qualname):
     return method
 
 
-def dict_merge(destination, source, overwrite=False, _nodes=None):
+def dict_merge(
+    destination, source, overwrite=False, _nodes=None, contatenate_sequences=False
+):
     """Merge the source into the destination"""
     if _nodes is None:
         _nodes = tuple()
@@ -34,11 +37,23 @@ def dict_merge(destination, source, overwrite=False, _nodes=None):
         if key in destination:
             _nodes += (str(key),)
             if isinstance(destination[key], Mapping) and isinstance(value, Mapping):
-                dict_merge(destination[key], value, overwrite=overwrite, _nodes=_nodes)
+                dict_merge(
+                    destination[key],
+                    value,
+                    overwrite=overwrite,
+                    _nodes=_nodes,
+                    contatenate_sequences=contatenate_sequences,
+                )
             elif value == destination[key]:
                 continue
             elif overwrite:
                 destination[key] = value
+            elif (
+                contatenate_sequences
+                and isinstance(destination[key], Sequence)
+                and isinstance(value, Sequence)
+            ):
+                destination[key] += value
             else:
                 raise ValueError("Conflict at " + ".".join(_nodes))
         else:


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jul 16, 2021, 16:50 GMT+2:***

Allow merging link attributes which have links:
```python
linkattrs1 = {"source": "A", "target": "B", links=[adict1]}

linkattrs2 = {"source": "A", "target": "B", links=[adict2, adict3]}

linkattrs_merged = {"source": "A", "target": "B", links=[adict1, adict2, adict3]}
```

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/10*