### PR TITLE
import from collections instead of collections.abc is deprecated

### DIFF
--- a/ewokscore/graph.py
+++ b/ewokscore/graph.py
@@ -2,7 +2,7 @@ import os
 import enum
 import networkx
 import json
-from collections import Mapping
+from collections.abc import Mapping
 from . import inittask
 from .utils import qualname
 from .utils import dict_merge

--- a/ewokscore/hashing.py
+++ b/ewokscore/hashing.py
@@ -1,6 +1,6 @@
 import random
 import hashlib
-from collections import Mapping, Iterable, Set
+from collections.abc import Mapping, Iterable, Set
 import numpy
 from .utils import qualname
 

--- a/ewokscore/task.py
+++ b/ewokscore/task.py
@@ -1,4 +1,4 @@
-from collections import Mapping
+from collections.abc import Mapping
 from . import hashing
 from .variable import VariableContainer
 from .variable import VariableContainerNamespace

--- a/ewokscore/utils.py
+++ b/ewokscore/utils.py
@@ -1,6 +1,5 @@
 import importlib
-from collections import Mapping
-from collections import Sequence
+from collections.abc import Mapping, Sequence
 
 
 def qualname(obj):

--- a/ewokscore/variable.py
+++ b/ewokscore/variable.py
@@ -3,7 +3,7 @@ import string
 import random
 import json
 from numbers import Integral
-from collections import Mapping, MutableMapping, Iterable, Sequence
+from collections.abc import Mapping, MutableMapping, Iterable, Sequence
 from contextlib import contextmanager
 from . import hashing
 


### PR DESCRIPTION
***In GitLab by @woutdenolf on Aug 2, 2021, 11:46 GMT+2:***



**Assignees:** @woutdenolf

**Reviewers:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/22*