### PR TITLE
move TaskWithProgress to separate module

### DIFF
--- a/ewokscore/__init__.py
+++ b/ewokscore/__init__.py
@@ -1,4 +1,5 @@
 from .task import Task  # noqa: F401
+from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .graph import load_graph  # noqa: F401
 from .graph import execute_graph  # noqa: F401
 

--- a/ewokscore/task.py
+++ b/ewokscore/task.py
@@ -4,8 +4,6 @@ from .variable import VariableContainer
 from .variable import VariableContainerNamespace
 from .variable import ReadOnlyVariableContainerNamespace
 from .registration import Registered
-from .progress import BaseProgress
-from typing import Union
 
 
 class TaskInputError(ValueError):
@@ -254,29 +252,3 @@ class Task(Registered, hashing.UniversalHashable, register=False):
     def run(self):
         """To be implemented by the derived classes"""
         raise NotImplementedError
-
-
-class TaskWithProgress(Task):
-    """
-    Task within a progress to display task advancement
-    """
-
-    def __init__(
-        self, inputs=None, varinfo=None, progress: Union[None, BaseProgress] = None
-    ):
-        super().__init__(inputs=inputs, varinfo=varinfo)
-        self._task_progress = progress
-
-    @property
-    def progress(self) -> Union[None, int]:
-        """Task advancement. If a task progress is not provided then return
-        None"""
-        if self._task_progress is not None:
-            return self._task_progress.progress
-        else:
-            return None
-
-    @progress.setter
-    def progress(self, progress: int):
-        if self._task_progress:
-            self._task_progress.progress = progress

--- a/ewokscore/taskwithprogress.py
+++ b/ewokscore/taskwithprogress.py
@@ -1,0 +1,29 @@
+from typing import Union
+from .task import Task
+from .progress import BaseProgress
+
+
+class TaskWithProgress(Task):
+    """
+    Task within a progress to display task advancement
+    """
+
+    def __init__(
+        self, inputs=None, varinfo=None, progress: Union[None, BaseProgress] = None
+    ):
+        super().__init__(inputs=inputs, varinfo=varinfo)
+        self._task_progress = progress
+
+    @property
+    def progress(self) -> Union[None, int]:
+        """Task advancement. If a task progress is not provided then return
+        None"""
+        if self._task_progress is not None:
+            return self._task_progress.progress
+        else:
+            return None
+
+    @progress.setter
+    def progress(self, progress: int):
+        if self._task_progress:
+            self._task_progress.progress = progress

--- a/ewokscore/tests/examples/tasks/sumlist.py
+++ b/ewokscore/tests/examples/tasks/sumlist.py
@@ -1,4 +1,4 @@
-from ewokscore.task import TaskWithProgress
+from ewokscore.taskwithprogress import TaskWithProgress
 
 
 class SumList(TaskWithProgress, input_names=["list"], output_names=["sum"]):


### PR DESCRIPTION
***In GitLab by @woutdenolf on Aug 2, 2021, 11:51 GMT+2:***

I think it is best if everyone learns to import common things directly from ewokscore which gives us the liberty to move stuff around. For example:
```python
from ewokscore import TaskWithProgress
```

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/23*