### PR TITLE
[CI] add doc pages deployement

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -13,5 +13,8 @@ test-3.8:
 test-3.9:
   extends: ".test-3.9"
 
-sphinx:
-  extends: ".sphinx"
+ewoksorange_sphinx_and_artifacts:
+  extends: ".sphinx_and_artifacts"
+
+pages:
+  extends: ".pages"


### PR DESCRIPTION
***In GitLab by @payno on Aug 4, 2021, 09:32 GMT+2:***

Once merged and CI ended this will create ewokscore documentation in: https://workflow.gitlab-pages.esrf.fr/ewoks/ewokscore

_note: the step insuring documentation deployment must be named 'pages' otherwise deployment is not done._

**Reviewers:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/26*