### PR TITLE
[doc] fix typo ewosk vs ewoks

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,9 +1,9 @@
-ewoskcore |release|
+ewokscore |release|
 ===================
 
-ewoskcore provides an API for defining workflows in Ewoks.
+ewokscore provides an API for defining workflows in Ewoks.
 
-ewoskcore has been developed by the `Software group <http://www.esrf.eu/Instrumentation/software>`_ of the `European Synchrotron <https://www.esrf.eu/>`_.
+ewokscore has been developed by the `Software group <http://www.esrf.eu/Instrumentation/software>`_ of the `European Synchrotron <https://www.esrf.eu/>`_.
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
***In GitLab by @payno on Aug 6, 2021, 07:59 GMT+2:***



**Reviewers:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/30*