### PR TITLE
allow specifying the registry name explicitly for dynamic instantation

### DIFF
--- a/ewokscore/registration.py
+++ b/ewokscore/registration.py
@@ -1,10 +1,11 @@
+from typing import Optional, List
 from . import utils
 
 
 class Registered:
     _SUBCLASS_REGISTRY = None
 
-    def __init_subclass__(cls, register=True, **kwargs):
+    def __init_subclass__(cls, register=True, registry_name=None, **kwargs):
         super().__init_subclass__(**kwargs)
 
         # Ensures that not all subclasses share the same registry
@@ -16,20 +17,24 @@ class Registered:
             return
 
         # Register the subclass
-        reg_name = cls.__REGISTRY_NAME = utils.qualname(cls)
+        if registry_name:
+            reg_name = registry_name
+        else:
+            reg_name = utils.qualname(cls)
         ecls = cls._SUBCLASS_REGISTRY.get(reg_name)
         if ecls is not None:
             raise NotImplementedError(
                 f"Registry name {reg_name} is already taken by {repr(ecls)}"
             )
+        cls.__REGISTRY_NAME = reg_name
         cls._SUBCLASS_REGISTRY[reg_name] = cls
 
     @classmethod
-    def class_registry_name(cls):
+    def class_registry_name(cls) -> Optional[str]:
         return cls.__REGISTRY_NAME
 
     @classmethod
-    def get_subclass_names(cls):
+    def get_subclass_names(cls) -> List[str]:
         return list(cls._SUBCLASS_REGISTRY.keys())
 
     @classmethod


### PR DESCRIPTION
***In GitLab by @woutdenolf on Aug 19, 2021, 18:11 GMT+2:***

This can be used to create wrapper tasks for anything from which we can retrieve the input and output signatures.

One example is registering a Task class for a (native) Orange widget:

```python
def register_owwidget_task(widget_qualname):
    widget_class = import_qualname(widget_qualname)
    if not issubclass(widget_class, OWWidget):
        raise TypeError(widget_class, "expected to be a OWWidget")

    registry_name = widget_qualname + ".wrapper"
    if registry_name in Task.get_subclass_names():
        return Task.get_subclass(registry_name)

    class WrapperTask(
        Task,
        input_names=widget_class.input_names(),
        output_names=widget_class.output_names(),
        registry_name=registry_name,
    ):
        ...
```

The full qualifier name of `WrapperTask` is always the same so we need to specify it manually, in which case you are also responsible of uniqueness of course.

Another use case would be when you want to move a task class to a different module but don't want to break existing graphs.

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/37*