### PR TITLE
Resolve "load graph: more flexible submodel discovery"

### DIFF
--- a/ewokscore/graph/serialize.py
+++ b/ewokscore/graph/serialize.py
@@ -32,12 +32,18 @@ def ewoks_jsonload_hook(items):
     return dict(map(_ewoks_jsonload_hook_pair, items))
 
 
-def graph_full_path(path, root_dir=None):
-    if os.path.isabs(path):
-        return path
-    if root_dir:
+def graph_full_path(path, root_dir=None, possible_extensions=tuple()):
+    if not os.path.isabs(path) and root_dir:
         path = os.path.join(root_dir, path)
-    return os.path.abspath(path)
+    path = os.path.abspath(path)
+    if os.path.exists(path):
+        return path
+    root, _ = os.path.splitext(path)
+    for new_ext in possible_extensions:
+        new_full_path = root + new_ext
+        if os.path.exists(new_full_path):
+            return new_full_path
+    raise FileNotFoundError(path)
 
 
 def set_graph_defaults(graph_as_dict):
@@ -96,8 +102,10 @@ def load(
                 representation = GraphRepresentation.json
             elif source.endswith(".yml"):
                 representation = GraphRepresentation.yaml
-            else:
+            elif "{" in source and "}" in source:
                 representation = GraphRepresentation.json_string
+            else:
+                representation = GraphRepresentation.json
     if not source:
         graph = networkx.DiGraph()
     elif isinstance(source, networkx.Graph):
@@ -108,7 +116,7 @@ def load(
         set_graph_defaults(source)
         graph = networkx.readwrite.json_graph.node_link_graph(source)
     elif representation == GraphRepresentation.json:
-        source = graph_full_path(source, root_dir)
+        source = graph_full_path(source, root_dir, possible_extensions=(".json",))
         with open(source, mode="r") as f:
             source = json.load(f, object_pairs_hook=ewoks_jsonload_hook)
         set_graph_defaults(source)
@@ -118,7 +126,9 @@ def load(
         set_graph_defaults(source)
         graph = networkx.readwrite.json_graph.node_link_graph(source)
     elif representation == GraphRepresentation.yaml:
-        source = graph_full_path(source, root_dir)
+        source = graph_full_path(
+            source, root_dir, possible_extensions=(".yml", ".yaml")
+        )
         with open(source, mode="r") as f:
             source = yaml.load(f, yaml.Loader)
         set_graph_defaults(source)

--- a/ewokscore/graph/taskgraph.py
+++ b/ewokscore/graph/taskgraph.py
@@ -115,13 +115,21 @@ class TaskGraph:
         self,
         source=None,
         representation: Optional[Union[serialize.GraphRepresentation, str]] = None,
+        subgraph_representation: Optional[
+            Union[serialize.GraphRepresentation, str]
+        ] = None,
         root_dir: Optional[str] = None,
     ) -> None:
         graph = serialize.load(
             source=source, representation=representation, root_dir=root_dir
         )
 
-        subgraphs = get_subgraphs(graph, root_dir=root_dir)
+        if subgraph_representation is not None:
+            representation = subgraph_representation
+
+        subgraphs = get_subgraphs(
+            graph, root_dir=root_dir, representation=representation
+        )
         if subgraphs:
             # Extract
             edges, update_attrs = extract_graph_nodes(graph, subgraphs)

--- a/ewokscore/tests/test_graph_serialize.py
+++ b/ewokscore/tests/test_graph_serialize.py
@@ -1,0 +1,75 @@
+import pytest
+import json
+import yaml
+from ewokscore.graph import load_graph
+
+
+@pytest.mark.parametrize("with_ext", [True, False])
+@pytest.mark.parametrize("representation", ["json", "yaml", None])
+def test_graph_discovery(representation, with_ext, tmpdir):
+    subgraph = {
+        "graph": {"input_nodes": [{"id": "in", "node": "subnode1"}]},
+        "nodes": [
+            {
+                "id": "subnode1",
+                "task_type": "method",
+                "task_identifier": "dummy",
+                "default_inputs": [
+                    {"name": "name", "value": "subnode1"},
+                    {"name": "value", "value": 0},
+                ],
+            }
+        ],
+    }
+
+    graph = {
+        "nodes": [
+            {
+                "id": "node1",
+                "task_type": "method",
+                "task_identifier": "dummy",
+                "default_inputs": [
+                    {"name": "name", "value": "node1"},
+                    {"name": "value", "value": 0},
+                ],
+            },
+            {"id": "node2", "task_type": "graph", "task_identifier": "subgraph"},
+        ],
+        "links": [
+            {
+                "source": "node1",
+                "target": "node2",
+                "sub_target": "in",
+                "data_mapping": [
+                    {"target_input": "value", "source_output": "return_value"}
+                ],
+            }
+        ],
+    }
+
+    ext = ""
+    if representation == "yaml":
+        dump = yaml.dump
+        if with_ext:
+            ext = ".yml"
+    elif representation == "json":
+        dump = json.dump
+        if with_ext:
+            ext = ".json"
+    else:
+        dump = json.dump
+        if with_ext:
+            ext = ".json"
+
+    destination = str(tmpdir / "subgraph" + ext)
+    with open(destination, mode="w") as f:
+        dump(subgraph, f)
+    destination = str(tmpdir / "graph" + ext)
+    with open(destination, mode="w") as f:
+        dump(graph, f)
+
+    ewoksgraph = load_graph(
+        "graph", representation=representation, root_dir=str(tmpdir)
+    )
+
+    assert set(ewoksgraph.graph.nodes) == {"node1", ("node2", "subnode1")}


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 15, 2022, 11:09 GMT+1:***

Closes #25

Suppose you have a graph and a sub graph:
```
/path/to/graphs/mygraphfilename.json
/path/to/graphs/mysubmodelfilename.json
```

## Before this MR

The subgraph needs to be specified in the super graph like this:

```json
{"id": "node2", "task_type": "graph", "task_identifier": "mysubmodelfilename.json"}
```

Then the graph can be loaded like this

```python
load_graph(source="mygraphfilename.json", root_dir="/path/to/graphs")
```

## After this MR

The subgraph can be specified without extension:

```json
{"id": "node1", "task_type": "graph", "task_identifier": "mysubmodelfilename"}
```

Loading can also be done without extension

```python
load_graph(source="mygraphfilename", root_dir="/path/to/graphs")
```

### Non-json file format

If you have another file format

```
/path/to/graphs/mygraphfilename.yaml
/path/to/graphs/mysubmodelfilename.yaml
```

you can do this

```python
load_graph(source="mygraphfilename", representation="yaml", root_dir="/path/to/graphs")
```

without changing `"task_identifier": "mysubmodelfilename"`

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/105*