### PR TITLE
Resolve "uhash for large data"

### DIFF
--- a/ewokscore/hashing.py
+++ b/ewokscore/hashing.py
@@ -223,7 +223,7 @@ class UniversalHashable(HasUhash):
         elif isinstance(pre_uhash, (UniversalHash, HasUhash)):
             self.__pre_uhash = pre_uhash
         else:
-            raise TypeError(pre_uhash, type(pre_uhash))
+            self.__pre_uhash = uhash(pre_uhash)
 
     @classmethod
     def class_nonce(cls):

--- a/ewokscore/tests/test_variable.py
+++ b/ewokscore/tests/test_variable.py
@@ -333,3 +333,30 @@ def test_variable_container_cleanup_references():
     assert len(gc.get_referrers(obj)) == nref_start
 
     assert uhash == var2.uhash
+
+
+def test_variable_fixed_uhash():
+    class MyClass:
+        pass
+
+    var = Variable(value=MyClass, varinfo={"enable_hashing": True})
+    with pytest.raises(TypeError):
+        assert var.uhash
+
+    var = Variable(
+        value=MyClass, varinfo={"enable_hashing": True, "uhash_data": "some data"}
+    )
+    assert var.uhash
+
+    var1 = Variable(value=10, varinfo={"enable_hashing": True, "uhash_data": None})
+    var2 = Variable(
+        value=10, varinfo={"enable_hashing": True, "uhash_data": "some data"}
+    )
+    var3 = Variable(
+        value=20, varinfo={"enable_hashing": True, "uhash_data": "some data"}
+    )
+    assert var1.uhash
+    assert var2.uhash
+    assert var3.uhash
+    assert var1.uhash != var2.uhash
+    assert var2.uhash == var3.uhash

--- a/ewokscore/variable.py
+++ b/ewokscore/variable.py
@@ -49,6 +49,9 @@ class Variable(hashing.UniversalHashable):
         elif not isinstance(varinfo, Mapping):
             raise TypeError(varinfo, type(varinfo))
 
+        if pre_uhash is None:
+            pre_uhash = varinfo.get("uhash_data", None)
+
         if data_proxy is not None:
             pre_uhash = data_proxy.uri.uhash
             instance_nonce = None


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 15, 2022, 13:15 GMT+1:***

Closes #26

When hashing a `Variable` we may not want to hash the actual data because:

- the data is too large
- the data is location specific (like a full path name)

I added a new key to varinfo:

```python
var = Variable(value=..., varinfo={"uhash_data": "hashed-instead-of-the-value"})
```

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/106*