### PR TITLE
Resolve "versioning of graph representation"

### DIFF
--- a/doc/definitions.rst
+++ b/doc/definitions.rst
@@ -67,6 +67,7 @@ Graph attributes
 ^^^^^^^^^^^^^^^^
 * *id* (optional): graph identifier unique to a database of graphs
 * *label* (optional): non-unique label to be used when identifying a graph for human consumption
+* *version* (optional): the version to the representation (Default: "1.0")
 * *input_nodes* (optional): nodes that are expected to be used as link targets when the graph
   is used as a subgraph.
 * *output_nodes* (optional): nodes that are expected to be used as link sources when the graph
@@ -150,7 +151,7 @@ Node attributes
         }
 * *inputs_complete* (optional): set to `True` when the default input covers all required input
   (used for method and script as the required inputs are unknown)
-* *conditions_else_value* (optional): value used in conditional links to indicate the *else* value (`None` by default)
+* *conditions_else_value* (optional): value used in conditional links to indicate the *else* value (Default: `None`)
 * *default_error_node* (optional): when set to `True` all nodes without error handler will be linked to this node.
 * *default_error_attributes* (optional): when `default_error_node=True` this dictionary is used as attributes for the
   error handler links. The default is `{"map_all_data": True}`. The link attribute `"on_error"` is forced to be `True`.

--- a/ewokscore/graph/update/__init__.py
+++ b/ewokscore/graph/update/__init__.py
@@ -1,0 +1,88 @@
+from typing import Callable, Optional
+import networkx
+from packaging.version import parse as parse_version
+import logging
+import importlib
+
+# Major version: increment when changing the existing schema
+# Minor version: increment when adding features or deprecating the existing schema
+DEFAULT_VERSION = parse_version("1.0")
+LATEST_VERSION = parse_version("1.0")
+
+# Map graph versions to ewokscore version bounds. Whenever we change the schema
+# which the current ewokscore version needs and updating is not possible:
+#   - increment the ewokscore version
+#   - use that version as upper bound of the last item of _VERSION_BOUNDS
+#   - use that version as lower bound of a new item of _VERSION_BOUNDS
+_VERSION_BOUNDS = None
+
+
+def get_version_bounds() -> dict:
+    global _VERSION_BOUNDS
+    if _VERSION_BOUNDS:
+        return _VERSION_BOUNDS
+
+    _VERSION_BOUNDS = dict()
+    _VERSION_BOUNDS[parse_version("0.0")] = parse_version("0.0"), parse_version("0.0.1")
+    _VERSION_BOUNDS[parse_version("0.1")] = parse_version("0.1.0-rc"), None
+    _VERSION_BOUNDS[parse_version("0.2")] = parse_version("0.1.0-rc"), None
+    _VERSION_BOUNDS[parse_version("1.0")] = parse_version("0.1.0-rc"), None
+    return _VERSION_BOUNDS
+
+
+logger = logging.getLogger(__name__)
+
+
+def update_graph(graph: networkx.DiGraph) -> bool:
+    """Updates the graph to a higher version (returns `True`) or raises an
+    exception. If the version is know it wil provide library version bounds
+    in the exception message. Returns `False` when the graph does not need
+    any update.
+    """
+    version = graph.graph.get("version", None)
+    if version is None:
+        version = DEFAULT_VERSION
+        graph.graph["version"] = str(version)
+        logger.warning(f'Graph is not versioned: assume version "{version}"')
+    else:
+        version = parse_version(version)
+    if version == LATEST_VERSION:
+        return False
+
+    update_method = _get_update_method(version)
+    if update_method:
+        before = graph.graph.get("version", None)
+        try:
+            update_method(graph)
+        except Exception:
+            pass  # version is not longer supported
+        else:
+            after = graph.graph.get("version", None)
+            assert before != after, "graph conversion did not update the version"
+            return True
+
+    lbound, ubound = get_version_bounds().get(version, (None, None))
+    if lbound and ubound:
+        raise ValueError(
+            f'Graph version "{version}" requires another library version: python -m pip install "ewokscore>={lbound},<{ubound}"`'
+        )
+    elif lbound:
+        raise ValueError(
+            f'Graph version "{version}" requires another library version: python -m pip install "ewokscore>={lbound}"'
+        )
+    elif ubound:
+        raise ValueError(
+            f'Graph version "{version}" requires another library version: python -m pip install "ewokscore<{ubound}"'
+        )
+    else:
+        raise ValueError(
+            f'Graph version "{version}" is either invalid or requires a newer library version: python -m pip install --upgrade ewokscore'
+        )
+
+
+def _get_update_method(version) -> Optional[Callable[[networkx.DiGraph], None]]:
+    try:
+        mod = importlib.import_module(__name__ + ".v" + str(version).replace(".", "_"))
+    except ImportError:
+        return None
+    return mod.update_graph

--- a/ewokscore/graph/update/v0_0.py
+++ b/ewokscore/graph/update/v0_0.py
@@ -1,0 +1,6 @@
+import networkx
+
+
+def update_graph(graph: networkx.DiGraph) -> None:
+    """This version is for testing"""
+    raise RuntimeError("not supported")

--- a/ewokscore/graph/update/v0_1.py
+++ b/ewokscore/graph/update/v0_1.py
@@ -1,0 +1,6 @@
+import networkx
+
+
+def update_graph(graph: networkx.DiGraph) -> None:
+    """This version is for testing"""
+    pass

--- a/ewokscore/graph/update/v0_2.py
+++ b/ewokscore/graph/update/v0_2.py
@@ -1,0 +1,6 @@
+import networkx
+
+
+def update_graph(graph: networkx.DiGraph) -> None:
+    """This version is for testing"""
+    graph.graph["version"] = "1.0"

--- a/ewokscore/graph/validate.py
+++ b/ewokscore/graph/validate.py
@@ -1,9 +1,18 @@
 import networkx
+
 from ..inittask import validate_task_executable
 from .analysis import required_predecessors
+from .update import update_graph
 
 
 def validate_graph(graph: networkx.DiGraph) -> None:
+    while update_graph(graph):
+        pass
+    _validate_nodes(graph)
+    _validate_links(graph)
+
+
+def _validate_nodes(graph: networkx.DiGraph) -> None:
     for node_id, node_attrs in graph.nodes.items():
         validate_task_executable(node_id, node_attrs)
 
@@ -29,6 +38,8 @@ def validate_graph(graph: networkx.DiGraph) -> None:
                     )
                 inputs_from_required[name] = source_id
 
+
+def _validate_links(graph: networkx.DiGraph) -> None:
     for (source, target), linkattrs in graph.edges.items():
         err_msg = f"Link {source}->{target}: '{{}}' and '{{}}' cannot be used together"
         if linkattrs.get("map_all_data") and linkattrs.get("data_mapping"):

--- a/ewokscore/tests/test_graph_validate.py
+++ b/ewokscore/tests/test_graph_validate.py
@@ -1,0 +1,43 @@
+import pytest
+import logging
+from ewokscore.graph import load_graph
+from ewokscore.graph.update import LATEST_VERSION
+
+LATEST_VERSION = str(LATEST_VERSION)
+
+
+def test_graph_version(caplog):
+    # Update of the default version
+    with caplog.at_level(logging.WARNING):
+        assert_load({})
+
+    # Update of the latest version
+    assert_load({"graph": {"version": LATEST_VERSION}})
+
+    # Update method which raises an exception
+    with pytest.raises(
+        ValueError,
+        match='Graph version "0.0" requires another library version: python -m pip install "ewokscore>=0.0,<0.0.1"',
+    ):
+        load_graph({"graph": {"version": "0.0"}})
+
+    # Update method which does not update the version
+    with pytest.raises(
+        AssertionError,
+        match="graph conversion did not update the version",
+    ):
+        load_graph({"graph": {"version": "0.1"}})
+
+    # Correct update method
+    assert_load({"graph": {"version": "0.2"}})
+
+    # Version does not exist
+    with pytest.raises(
+        ValueError,
+        match='Graph version "99999.0" is either invalid or requires a newer library version: python -m pip install --upgrade ewokscore',
+    ):
+        load_graph({"graph": {"version": "99999.0"}})
+
+
+def assert_load(adict: dict):
+    load_graph(adict).graph.graph["version"] == LATEST_VERSION


### PR DESCRIPTION
***In GitLab by @woutdenolf on May 5, 2022, 14:44 GMT+2:***

Closes #30

A new library reading an old graph will try to update the graph. When updating is not possible it will raise an exception with a message like this:

```
Graph version "1.0" requires another library version: python -m pip install "ewokscore>=0.1,<3.2"
```

An old library reading a new graph will raise an exception with a message like this:

```
Graph version "2.5" is either invalid or requires a newer library version: python -m pip install --upgrade ewokscore
```

**Assignees:** @woutdenolf

**Reviewers:** @payno

**Approved by:** @payno

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/130*