### PR TITLE
bump version

### DIFF
--- a/ewokscore/__init__.py
+++ b/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.1.0-rc.8"
+__version__ = "0.1.0-rc.9"


### PR DESCRIPTION
***In GitLab by @woutdenolf on May 20, 2022, 16:53 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/136*