### PR TITLE
setuptools should not import when installing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=46.4<63",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 3, 2022, 21:27 GMT+2:***

https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/73

**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/140*