### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG.md
 
-## 0.2.0 (unreleased)
+## 0.3.0 (unreleased)
+
+## 0.2.0
+
+New features:
+   - Workflow inputs and outputs: use `task_identifier` to select nodes
 
 ## 0.1.1
 
@@ -9,7 +14,7 @@ Bug fixes:
 
 ## 0.1.0
 
-Added:
+New features:
   - `Graph` class as an API for all task graphs
   - `Task` class as an API for all tasks
   - `Variable` class for task parameters, hashing and

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Oct 26, 2022, 16:22 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/168*