### PR TITLE
Remove missing variable from container variable_values

### DIFF
--- a/src/ewokscore/tests/test_variable.py
+++ b/src/ewokscore/tests/test_variable.py
@@ -1,6 +1,7 @@
 import gc
 import pytest
 from contextlib import contextmanager
+from ewokscore.missing_data import MISSING_DATA
 from ewokscore.variable import Variable, VariableContainer
 from ewokscore.variable import MutableVariableContainer
 
@@ -387,3 +388,34 @@ def test_variable_none_dump(scheme, tmpdir):
     var = Variable(value=None, varinfo={"root_uri": str(tmpdir), "scheme": scheme})
     var.dump()
     var.load()
+
+
+def test_variable_container_values():
+    c = MutableVariableContainer(
+        value={"a": None, "b": MISSING_DATA, 2: "Two", 3: MISSING_DATA}
+    )
+    assert not c["a"].is_missing()
+    assert c["b"].is_missing()
+    assert c.variable_values == {"a": None, 2: "Two"}
+    assert c.named_variable_values == {"a": None}
+    assert c.positional_variable_values == (
+        MISSING_DATA,
+        MISSING_DATA,
+        "Two",
+        MISSING_DATA,
+    )
+
+    c["a"] = MISSING_DATA
+    c["b"] = None
+    c[1] = "One"
+    c[2] = MISSING_DATA
+    assert c["a"].is_missing()
+    assert not c["b"].is_missing()
+    assert c.variable_values == {"b": None, 1: "One"}
+    assert c.named_variable_values == {"b": None}
+    assert c.positional_variable_values == (
+        MISSING_DATA,
+        "One",
+        MISSING_DATA,
+        MISSING_DATA,
+    )

--- a/src/ewokscore/variable.py
+++ b/src/ewokscore/variable.py
@@ -37,8 +37,8 @@ class Variable(hashing.UniversalHashable):
 
     def __init__(
         self,
-        value=missing_data.MISSING_DATA,
-        metadata=missing_data.MISSING_DATA,
+        value: Any = missing_data.MISSING_DATA,
+        metadata: Any = missing_data.MISSING_DATA,
         varinfo: Optional[dict] = None,
         data_uri: Union[DataUri, str, None] = None,
         data_proxy: Optional[DataProxy] = None,
@@ -204,7 +204,7 @@ class VariableContainer(Variable, Mapping):
 
     def __init__(
         self,
-        value=missing_data.MISSING_DATA,
+        value: Any = missing_data.MISSING_DATA,
         varinfo: Optional[dict] = None,
         data_uri: Optional[DataUri] = None,
         data_proxy: Optional[DataProxy] = None,
@@ -424,7 +424,7 @@ class VariableContainer(Variable, Mapping):
 
     @property
     def variable_values(self):
-        return {k: v.value for k, v in self.items()}
+        return {k: v.value for k, v in self.items() if not v.is_missing()}
 
     @property
     def variable_data_proxies(self):
@@ -455,7 +455,11 @@ class VariableContainer(Variable, Mapping):
 
     @property
     def named_variable_values(self):
-        return {k: v.value for k, v in self.items() if isinstance(k, str)}
+        return {
+            k: v.value
+            for k, v in self.items()
+            if isinstance(k, str) and not v.is_missing()
+        }
 
     @property
     def positional_variable_values(self):


### PR DESCRIPTION
***In GitLab by @loichuder on Nov 4, 2022, 09:33 GMT+1:***

Fix #42 

~~Didn't change the tests, that are still passing. Perhaps we should add a test for this ? Should we add `MISSING_DATA` to the `VALUES` in https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/blob/ca76abc461e46fa36ca01575ae4b0cbb46831884/src/ewokscore/tests/test_variable.py#L7 ?~~

**EDIT: Added tests**

**Reviewers:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/171*