### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # CHANGELOG.md
 
-## 0.3.0 (unreleased)
+## 0.4.0 (unreleased)
 
-## 0.1.2
+## 0.3.0
+
+Breaking changes:
+   - `Variable` methods `variable_values`, `named_variable_values`, `positional_variable_values`
+     no longer values of type `MissingData`.
+
+## 0.2.1
 
 Bug fixes:
    - Store only "name" and "value" of dynamic inputs in node default inputs

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Nov 4, 2022, 17:25 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/172*