### PR TITLE
ewokci moved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Hidden files
 .*
+!.gitignore
+!.gitlab-ci.yml
+!.readthedocs.yaml
 
 # Byte / compiled / optimized
 *.py[cod]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,6 @@
 include:
-  - remote: https://gitlab.esrf.fr/workflow/ewoks/ewoksci/raw/main/.gitlab-ci-template.yml
+  - project: workflow/ewoksadmin/ewoksci
+    file: .gitlab-ci-template.yml
 
 test-3.6:
   extends: .test-3.6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-<a href="https://gitlab.esrf.fr/workflow/ewoks/ewoksci/-/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a>
+<a href="https://gitlab.esrf.fr/workflow/ewoksadmin/ewoksci/-/blob/main/CONTRIBUTING.md" target="_blank">CONTRIBUTING.md</a>


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jan 26, 2023, 11:21 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/174*