### PR TITLE
silx does not build on python 3.6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,9 +2,6 @@ include:
   - project: workflow/ewoksadmin/ewoksci
     file: .gitlab-ci-template.yml
 
-test-3.6:
-  extends: .test-3.6
-
 test-3.7:
   extends: .test-3.7
 
@@ -23,8 +20,8 @@ test-3.8-examples:
 build_sdist:
   extends: .build_sdist
 
-test_sdist-3.6:
-  extends: .test_sdist-3.6
+test_sdist-3.7:
+  extends: .test_sdist-3.7
 
 test_sdist-3.8-win:
   extends: .test_sdist-3.8-win


### PR DESCRIPTION
***In GitLab by @woutdenolf on Feb 27, 2023, 09:27 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/177*