### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.4.0 (unreleased)
 
+## 0.3.1
+
+Deprecations:
+   - ewoks event field "binding" is deprecated in favor of "engine"
+
 ## 0.3.0
 
 Breaking changes:

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 8, 2023, 11:00 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/179*