### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.4.0 (unreleased)
 
+## 0.3.2
+
+Changes:
+   - make discover_tasks_from_modules pickelable
+
 ## 0.3.1
 
 Deprecations:

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 23, 2023, 19:21 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/186*