### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # CHANGELOG.md
 
-## 0.4.0 (unreleased)
+## 0.5.0 (unreleased)
+
+## 0.4.0
+
+New features:
+   - CLI support inputs by label or task identifier
+
+Breaking changes:
+   - CLI option "--output" renamed to "--outputs"
 
 ## 0.3.3
 

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.3.3"
+__version__ = "0.4.0"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 27, 2023, 17:50 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/189*