### PR TITLE
Fix typo in documentation

### DIFF
--- a/doc/execute_io.rst
+++ b/doc/execute_io.rst
@@ -69,8 +69,8 @@ An example where we use the return value of two tasks as the workflow output
 
     results = execute_graph(
         "/path/to/file.json",
-        inputs=[{"id": "task1", "name":return_value", "new_name": "return_value1"},
-                {"id": "task2", "name":return_value", "new_name": "return_value2"}]
+        inputs=[{"id": "task1", "name": "return_value", "new_name": "return_value1"},
+                {"id": "task2", "name": "return_value", "new_name": "return_value2"}]
     )
 
     assert set(results) == {"return_value1", "return_value2"}


### PR DESCRIPTION
***In GitLab by @tvincent on Mar 29, 2023, 15:01 GMT+2:***



*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/191*