### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5.0 (unreleased)
 
+## 0.4.1
+
+Deprecations:
+   - Task properties that instantiate objects whenever used are replaced by functions
+
 ## 0.4.0
 
 New features:

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"


### PR DESCRIPTION
***In GitLab by @woutdenolf on May 15, 2023, 10:23 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/194*