### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5.0 (unreleased)
 
+## 0.4.2
+
+New features:
+   - Module can optionally be reloaded when discovering tasks
+
 ## 0.4.1
 
 Deprecations:

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.4.1"
+__version__ = "0.4.2"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 1, 2023, 18:10 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/199*