### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## 0.5.0 (unreleased)
 
+## 0.4.3
+
+New features:
+   - Module can optionally be reloaded when discovering tasks
+
 ## 0.4.2
 
 New features:

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/src/ewokscore/task_discovery.py
+++ b/src/ewokscore/task_discovery.py
@@ -9,9 +9,13 @@ from .task import Task
 
 
 def discover_tasks_from_modules(
-    *module_names: Iterable[str], task_type="class"
+    *module_names: Iterable[str], task_type="class", reload: bool = False
 ) -> Iterable[dict]:
-    return list(iter_discover_tasks_from_modules(*module_names, task_type=task_type))
+    return list(
+        iter_discover_tasks_from_modules(
+            *module_names, task_type=task_type, reload=reload
+        )
+    )
 
 
 def iter_discover_tasks_from_modules(


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 1, 2023, 18:37 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/200*