### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG.md
 
-## 0.6.0 (unreleased)
+## 0.7.0 (unreleased)
+
+## 0.6.0
+
+Changes:
+   - support executable scripts on linux (scripts that have a shebang)
 
 ## 0.5.3
 

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.5.3"
+__version__ = "0.6.0"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 20, 2023, 22:33 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/208*