### PR TITLE
numpy 2.0 not supported because of h5py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,118 +2,146 @@
 
 ## 0.8.0 (unreleased)
 
+## 0.7.3
+
+Changes:
+
+- numpy 2.0 is not supported
+
 ## 0.7.2
 
 Changes:
-   - replace deprecated pkg_resources
+
+- replace deprecated pkg_resources
 
 ## 0.7.1
 
 Changes:
-   - make notebook test flaky for python 3.7
+
+- make notebook test flaky for python 3.7
 
 ## 0.7.0
 
 New features:
-   - add support for jupyter notebooks as workflow tasks
+
+- add support for jupyter notebooks as workflow tasks
 
 ## 0.6.1
 
 Changes:
-   - executable scripts absolute path before execution
+
+- executable scripts absolute path before execution
 
 ## 0.6.0
 
 Changes:
-   - support executable scripts on linux (scripts that have a shebang)
+
+- support executable scripts on linux (scripts that have a shebang)
 
 ## 0.5.3
 
 Changes:
-   - modify task doc strings
+
+- modify task doc strings
 
 ## 0.5.2
 
 Changes:
-   - remove print statement from the task_discovery module
+
+- remove print statement from the task_discovery module
 
 ## 0.5.1
 
 Changes:
-   - By default, task discovery raises import errors when modules are specified and
-     logs import errors when importing all tasks
+
+- By default, task discovery raises import errors when modules are specified and
+  logs import errors when importing all tasks
 
 ## 0.5.0
 
 New features:
-   - Task discovery without the need to specify modules (using package entry points)
+
+- Task discovery without the need to specify modules (using package entry points)
 
 ## 0.4.3
 
 New features:
-   - Module can optionally be reloaded when discovering tasks
+
+- Module can optionally be reloaded when discovering tasks
 
 ## 0.4.2
 
 New features:
-   - Module can optionally be reloaded when discovering tasks
+
+- Module can optionally be reloaded when discovering tasks
 
 ## 0.4.1
 
 Deprecations:
-   - Task properties that instantiate objects whenever used are replaced by functions
+
+- Task properties that instantiate objects whenever used are replaced by functions
 
 ## 0.4.0
 
 New features:
-   - CLI support inputs by label or task identifier
+
+- CLI support inputs by label or task identifier
 
 Breaking changes:
-   - CLI option "--output" renamed to "--outputs"
+
+- CLI option "--output" renamed to "--outputs"
 
 ## 0.3.3
 
 Changes:
-   - tasks discovery includes the current working directory
+
+- tasks discovery includes the current working directory
 
 ## 0.3.2
 
 Changes:
-   - make discover_tasks_from_modules pickelable
+
+- make discover_tasks_from_modules pickelable
 
 ## 0.3.1
 
 Deprecations:
-   - ewoks event field "binding" is deprecated in favor of "engine"
+
+- ewoks event field "binding" is deprecated in favor of "engine"
 
 ## 0.3.0
 
 Breaking changes:
-   - `Variable` methods `variable_values`, `named_variable_values`, `positional_variable_values`
-     no longer values of type `MissingData`.
+
+- `Variable` methods `variable_values`, `named_variable_values`, `positional_variable_values`
+  no longer values of type `MissingData`.
 
 ## 0.2.1
 
 Bug fixes:
-   - Store only "name" and "value" of dynamic inputs in node default inputs
+
+- Store only "name" and "value" of dynamic inputs in node default inputs
 
 ## 0.2.0
 
 New features:
-   - Workflow inputs and outputs: use `task_identifier` to select nodes
+
+- Workflow inputs and outputs: use `task_identifier` to select nodes
 
 ## 0.1.1
 
 Bug fixes:
-   - Add missing `packaging` dependency
+
+- Add missing `packaging` dependency
 
 ## 0.1.0
 
 New features:
-  - `Graph` class as an API for all task graphs
-  - `Task` class as an API for all tasks
-  - `Variable` class for task parameters, hashing and
-     persistence (JSON, HDF5-Nexus)
-  - `load_graph` for loading graph from JSON or YAML
-  - `execute_graph` for naive task scheduling in a single thread
-  - Execution events based on python's logging facility
+
+- `Graph` class as an API for all task graphs
+- `Task` class as an API for all tasks
+- `Variable` class for task parameters, hashing and
+  persistence (JSON, HDF5-Nexus)
+- `load_graph` for loading graph from JSON or YAML
+- `execute_graph` for naive task scheduling in a single thread
+- Execution events based on python's logging facility

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
 packages=find:
 python_requires = >=3.6
 install_requires = 
-    numpy >=1.15
+    numpy >=1.15,<2
     networkx >=2
     silx >=1
     pyyaml >=5.1

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.7.2"
+__version__ = "0.7.3"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 13, 2024, 18:37 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/222*