### PR TITLE
the pyyaml 6.0.2rc1 package is broken for python 3.7 or lower

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # CHANGELOG.md
 
-## 0.8.0 (unreleased)
+## Unreleased
+
+## 0.7.4
+
+Big fixes:
+
+- the pyyaml 6.0.2rc1 package is broken for python 3.7 or lower
 
 ## 0.7.3
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,8 @@ install_requires =
     numpy >=1.15,<2
     networkx >=2
     silx >=1
-    pyyaml >=5.1
+    pyyaml >=5.1,!=6.0.2rc1; python_version < "3.8"
+    pyyaml >=5.1; python_version >= "3.8"
     h5py >=2.8
     packaging
     ewoksutils >=0.1.2

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.7.3"
+__version__ = "0.7.4"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jun 12, 2024, 17:36 GMT+2:***

closes #59

**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/227*