### PR TITLE
Explicitely type default input/output to Any

### DIFF
--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Optional, Union, Mapping
+from typing import Any, Optional, Union, Mapping
 
 from .hashing import UniversalHashable
 from .registration import Registered
@@ -193,7 +193,7 @@ class Task(Registered, UniversalHashable, register=False):
     def missing_inputs(self):
         return self.__missing_inputs_namespace
 
-    def get_input_value(self, key, default=missing_data.MISSING_DATA):
+    def get_input_value(self, key, default: Any = missing_data.MISSING_DATA):
         if self.missing_inputs[key]:
             return default
         return self.inputs[key]
@@ -257,7 +257,7 @@ class Task(Registered, UniversalHashable, register=False):
     def outputs(self):
         return self.__outputs_namespace
 
-    def get_output_value(self, key, default=missing_data.MISSING_DATA):
+    def get_output_value(self, key, default: Any = missing_data.MISSING_DATA):
         if self.missing_outputs[key]:
             return default
         return self.outputs[key]


### PR DESCRIPTION
***In GitLab by @loichuder on Jul 24, 2024, 09:53 GMT+2:***

Without this explicit typing, static type analyzers expect `default` to be compatible with `MissingData`

![image](https://gitlab.esrf.fr/workflow/ewoks/ewokscore/uploads/4bdfed3c4d6dfedf9d8bef9e1b7430e5/image.png)

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/229*