### PR TITLE
pyyaml was removed 6.0.2rc1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,7 @@ install_requires =
     numpy >=1.15,<2
     networkx >=2
     silx >=1
-    pyyaml >=5.1,!=6.0.2rc1; python_version < "3.8"
-    pyyaml >=5.1; python_version >= "3.8"
+    pyyaml >=5.1
     h5py >=2.8
     packaging
     ewoksutils >=0.1.2


### PR DESCRIPTION
***In GitLab by @woutdenolf on Aug 7, 2024, 17:56 GMT+2:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/230*