### PR TITLE
Refactor test_graph_serialize

### DIFF
--- a/src/ewokscore/tests/test_graph_serialize.py
+++ b/src/ewokscore/tests/test_graph_serialize.py
@@ -5,89 +5,102 @@ from ewokscore.graph import load_graph
 
 
 @pytest.mark.parametrize("with_ext", [True, False])
-@pytest.mark.parametrize("representation", ["json", "yaml", "json_module", None])
-def test_graph_discovery(representation, with_ext, tmpdir):
-    subgraph = {
-        "graph": {"id": "subgraph", "input_nodes": [{"id": "in", "node": "subnode1"}]},
-        "nodes": [
-            {
-                "id": "subnode1",
-                "task_type": "method",
-                "task_identifier": "dummy",
-                "default_inputs": [
-                    {"name": "name", "value": "subnode1"},
-                    {"name": "value", "value": 0},
-                ],
-            }
-        ],
-    }
-
-    graph = {
-        "graph": {"id": "graph"},
-        "nodes": [
-            {
-                "id": "node1",
-                "task_type": "method",
-                "task_identifier": "dummy",
-                "default_inputs": [
-                    {"name": "name", "value": "node1"},
-                    {"name": "value", "value": 0},
-                ],
-            },
-            {"id": "node2", "task_type": "graph", "task_identifier": "subgraph"},
-        ],
-        "links": [
-            {
-                "source": "node1",
-                "target": "node2",
-                "sub_target": "in",
-                "data_mapping": [
-                    {"target_input": "value", "source_output": "return_value"}
-                ],
-            }
-        ],
-    }
-
-    ext = ""
-    source = "graph"
-    root_dir = None
-    root_module = None
-    if representation == "yaml":
-        root_dir = str(tmpdir)
-        dump = yaml.dump
-        if with_ext:
-            ext = ".yml"
-    elif representation == "json":
-        root_dir = str(tmpdir)
-        dump = json.dump
-        if with_ext:
-            ext = ".json"
-    elif representation == "json_module":
-        root_module = "ewokscore.tests.examples.loadtest"
-        if with_ext:
-            source = root_module + "." + source
-        else:
-            representation = None
-        dump = None
-    else:
-        root_dir = str(tmpdir)
-        dump = json.dump
-        if with_ext:
-            ext = ".json"
-
-    if dump is not None:
-        destination = str(tmpdir / "subgraph" + ext)
-        with open(destination, mode="w") as f:
-            dump(subgraph, f)
-        destination = str(tmpdir / "graph" + ext)
-        with open(destination, mode="w") as f:
-            dump(graph, f)
+@pytest.mark.parametrize("with_representation", [True, False])
+def test_graph_discovery_json(with_ext, with_representation, tmpdir):
+    _dump_graph_and_subgraph(tmpdir, "json", with_ext)
 
     ewoksgraph = load_graph(
-        source,
-        representation=representation,
-        root_dir=root_dir,
-        root_module=root_module,
+        source="graph",
+        representation="json" if with_representation else None,
+        root_dir=str(tmpdir),
     )
 
     assert set(ewoksgraph.graph.nodes) == {"node1", ("node2", "subnode1")}
+
+
+@pytest.mark.parametrize("with_ext", [True, False])
+@pytest.mark.parametrize("with_representation", [True, False])
+def test_graph_discovery_yaml(with_ext, with_representation, tmpdir):
+    _dump_graph_and_subgraph(tmpdir, "yaml", with_ext)
+
+    ewoksgraph = load_graph(
+        source="graph",
+        representation="yaml" if with_representation else None,
+        root_dir=str(tmpdir),
+    )
+
+    assert set(ewoksgraph.graph.nodes) == {"node1", ("node2", "subnode1")}
+
+
+@pytest.mark.parametrize("with_representation", [True, False])
+def test_graph_discovery_json_module(with_representation):
+    if with_representation:
+        source = "ewokscore.tests.examples.loadtest.graph"
+        representation = "json_module"
+    else:
+        source = "graph"
+        representation = None
+
+    ewoksgraph = load_graph(
+        source=source,
+        representation=representation,
+        root_module="ewokscore.tests.examples.loadtest",
+    )
+
+    assert set(ewoksgraph.graph.nodes) == {"node1", ("node2", "subnode1")}
+
+
+def _dump_graph_and_subgraph(tmpdir, format, with_ext):
+    if format == "yaml":
+        dump = yaml.dump
+
+    if format == "json":
+        dump = json.dump
+
+    ext = f".{format}" if with_ext else ""
+    with open(tmpdir / "subgraph" + ext, mode="w") as f:
+        dump(_SUBGRAPH, f)
+    with open(tmpdir / "graph" + ext, mode="w") as f:
+        dump(_GRAPH, f)
+
+
+_SUBGRAPH = {
+    "graph": {"id": "subgraph", "input_nodes": [{"id": "in", "node": "subnode1"}]},
+    "nodes": [
+        {
+            "id": "subnode1",
+            "task_type": "method",
+            "task_identifier": "dummy",
+            "default_inputs": [
+                {"name": "name", "value": "subnode1"},
+                {"name": "value", "value": 0},
+            ],
+        }
+    ],
+}
+
+_GRAPH = {
+    "graph": {"id": "graph"},
+    "nodes": [
+        {
+            "id": "node1",
+            "task_type": "method",
+            "task_identifier": "dummy",
+            "default_inputs": [
+                {"name": "name", "value": "node1"},
+                {"name": "value", "value": 0},
+            ],
+        },
+        {"id": "node2", "task_type": "graph", "task_identifier": "subgraph"},
+    ],
+    "links": [
+        {
+            "source": "node1",
+            "target": "node2",
+            "sub_target": "in",
+            "data_mapping": [
+                {"target_input": "value", "source_output": "return_value"}
+            ],
+        }
+    ],
+}


### PR DESCRIPTION
***In GitLab by @loichuder on Aug 23, 2024, 16:02 GMT+2:***

Early step to resurrect !218 to fix #56 

I first refactor to test to be able to add easily the test for the `Path`. For this, I broke down the test in several "graph_format" tests introducting a `with_representation` bool as advised in https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/218#note_304221

It appears that there are several holes in the loading process, I'll underline them below.

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/231*