### PR TITLE
Replace `inputs_complete` by `force_start_node` to forcefully mark nodes as start nodes

### DIFF
--- a/doc/definitions.rst
+++ b/doc/definitions.rst
@@ -151,8 +151,8 @@ Node attributes
         {
             "default_inputs": [{"name":"a", "value":1}]
         }
-* *inputs_complete* (optional): set to `True` when the default inputs cover all required inputs
-  (used for *method*, *script* and *notebook* as their required inputs are unknown)
+* *force_start_node* (optional): when set to `True`, the node will be forcefully defined as a start node i.e. a node that should be executed before all others 
+(to be used as an escape hatch when the graph analysis fails to correctly assert the start nodes).
 * *conditions_else_value* (optional): value used in conditional links to indicate the *else* value (Default: `None`)
 * *default_error_node* (optional): when set to `True` all nodes without error handler will be linked to this node.
 * *default_error_attributes* (optional): when `default_error_node=True` this dictionary is used as attributes for the

--- a/src/ewokscore/graph/analysis.py
+++ b/src/ewokscore/graph/analysis.py
@@ -257,12 +257,11 @@ def has_required_predecessors(graph: networkx.DiGraph, node_id: NodeIdType) -> b
 def has_required_static_inputs(graph: networkx.DiGraph, node_id: NodeIdType) -> bool:
     """Returns True when the default inputs cover all required inputs."""
     node_attrs = graph.nodes[node_id]
-    inputs_complete = node_attrs.get("inputs_complete", None)
-    if isinstance(inputs_complete, bool):
-        # method and script tasks always have an empty `required_input_names`
-        # although they may have required input. This keyword is used the
-        # manually indicate that all required inputs are statically provided.
-        return inputs_complete
+    if node_attrs.get("task_type", None) != "class":
+        # Tasks that are not `class` (e.g. `method` and `script`)
+        # always have an empty `required_input_names`
+        # although they may have required input.
+        return False
     taskclass = get_task_class(node_id, node_attrs)
     static_inputs = {d["name"] for d in node_attrs.get("default_inputs", list())}
     return not (set(taskclass.required_input_names()) - static_inputs)
@@ -297,13 +296,23 @@ def node_has_noncovered_conditions(
     return False
 
 
+def node_is_start_node(graph: networkx.DiGraph, node_id: NodeIdType) -> bool:
+    node = graph.nodes[node_id]
+    if node.get("force_start_node", False):
+        return True
+
+    return not node_has_predecessors(graph, node_id)
+
+
 def start_nodes(graph: networkx.DiGraph) -> Set[NodeIdType]:
     """Nodes from which the graph execution starts"""
-    nodes = set(
-        node_id for node_id in graph.nodes if not node_has_predecessors(graph, node_id)
+
+    start_nodes: Set[NodeIdType] = set(
+        node_id for node_id in graph.nodes if node_is_start_node(graph, node_id)
     )
-    if nodes:
-        return nodes
+    if start_nodes:
+        return start_nodes
+
     return set(
         node_id
         for node_id in graph.nodes

--- a/src/ewokscore/graph/subgraph.py
+++ b/src/ewokscore/graph/subgraph.py
@@ -112,7 +112,7 @@ def _get_subnode_attributes(
     """Update all input node attributes of the subgraph with the graph node attributes from the super graph"""
     transfer_attributes = {
         "default_inputs",
-        "inputs_complete",
+        "start_node",
         "conditions_else_value",
         "default_error_node",
     }

--- a/src/ewokscore/tests/examples/graphs/self_trigger.py
+++ b/src/ewokscore/tests/examples/graphs/self_trigger.py
@@ -1,0 +1,54 @@
+from . import graph
+
+
+@graph
+def self_trigger():
+    task = "ewokscore.tests.examples.tasks.condsumtask.CondSumTask"
+    nodes = [
+        {
+            "id": "task1",
+            "default_inputs": [{"name": "a", "value": 1}],
+            "task_type": "class",
+            "task_identifier": task,
+            "force_start_node": True,
+        },
+        {
+            "id": "task2",
+            "default_inputs": [{"name": "b", "value": 1}],
+            "task_type": "class",
+            "task_identifier": task,
+        },
+        {
+            "id": "task3",
+            "task_type": "class",
+            "task_identifier": task,
+        },
+    ]
+    links = [
+        {
+            "source": "task1",
+            "target": "task1",
+            "data_mapping": [{"source_output": "result", "target_input": "b"}],
+            "conditions": [{"source_output": "too_small", "value": True}],
+        },
+        {
+            "source": "task1",
+            "target": "task3",
+            "data_mapping": [{"source_output": "result", "target_input": "a"}],
+        },
+        {
+            "source": "task2",
+            "target": "task3",
+            "data_mapping": [{"source_output": "result", "target_input": "b"}],
+        },
+    ]
+
+    # Cannot be executed with ewokscore execute_graph
+    expected = None
+
+    graph = {
+        "links": links,
+        "nodes": nodes,
+    }
+
+    return graph, expected

--- a/src/ewokscore/tests/test_examples.py
+++ b/src/ewokscore/tests/test_examples.py
@@ -63,6 +63,12 @@ def test_start_nodes():
     ewoksgraph = load_graph(graph)
     assert start_nodes(ewoksgraph.graph) == {"task1"}
 
+    graph, _ = get_graph("self_trigger")
+    ewoksgraph = load_graph(graph)
+    assert start_nodes(ewoksgraph.graph) == {"task1", "task2"}
+    ewoksgraph.graph.nodes["task1"].pop("force_start_node")
+    assert start_nodes(ewoksgraph.graph) == {"task2"}
+
 
 @pytest.mark.parametrize("graph_name", graph_names())
 @pytest.mark.parametrize(


### PR DESCRIPTION
***In GitLab by @loichuder on Aug 30, 2024, 11:27 GMT+2:***

Fix #58 

Related to https://gitlab.esrf.fr/workflow/ewoks/ewoksppf/-/issues/16

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/236*