### PR TITLE
Introduce SchemaMetadata to streamline the schema version handling

### DIFF
--- a/src/ewokscore/graph/schema/__init__.py
+++ b/src/ewokscore/graph/schema/__init__.py
@@ -1,8 +1,27 @@
-from typing import Callable, Optional, Union
+from typing import Dict, Union
 import networkx
 from packaging.version import parse as parse_version, Version
 import logging
-import importlib
+
+from .metadata import SchemaMetadata
+
+from .update import from_v1_0_to_v1_1, v0_update
+
+
+_VERSIONS = None
+
+
+def get_versions() -> Dict[Version, SchemaMetadata]:
+    global _VERSIONS
+    if _VERSIONS is not None:
+        return _VERSIONS
+
+    return {
+        parse_version("0.0"): SchemaMetadata(("0.0", "0.0.1"), v0_update),
+        parse_version("1.0"): SchemaMetadata(("0.1.0-rc", None), from_v1_0_to_v1_1),
+        parse_version("1.1"): SchemaMetadata(("0.1.0-rc", None), None),
+    }
+
 
 # Major version: increment when changing the existing schema
 # Minor version: increment when adding features or deprecating the existing schema
@@ -10,27 +29,6 @@ LATEST_VERSION = parse_version("1.1")
 
 # The default version may be set to something else if we don't want the latest version to be the default
 DEFAULT_VERSION = LATEST_VERSION
-
-# Map graph versions to ewokscore version bounds. Whenever we change the schema
-# which the current ewokscore version needs and updating is not possible:
-#   - increment the ewokscore version
-#   - use that version as upper bound of the last item of _VERSION_BOUNDS
-#   - use that version as lower bound of a new item of _VERSION_BOUNDS
-_VERSION_BOUNDS = None
-
-
-def get_version_bounds() -> dict:
-    global _VERSION_BOUNDS
-    if _VERSION_BOUNDS:
-        return _VERSION_BOUNDS
-
-    _VERSION_BOUNDS = dict()
-    _VERSION_BOUNDS[parse_version("0.0")] = parse_version("0.0"), parse_version("0.0.1")
-    _VERSION_BOUNDS[parse_version("0.1")] = parse_version("0.1.0-rc"), None
-    _VERSION_BOUNDS[parse_version("0.2")] = parse_version("0.1.0-rc"), None
-    _VERSION_BOUNDS[parse_version("1.0")] = parse_version("0.1.0-rc"), None
-    _VERSION_BOUNDS[parse_version("1.1")] = parse_version("0.1.0-rc"), None
-    return _VERSION_BOUNDS
 
 
 logger = logging.getLogger(__name__)
@@ -70,7 +68,8 @@ def update_graph_schema(graph: networkx.DiGraph):
     """
     schema_version = parse_version(graph.graph["schema_version"])
 
-    update_method = _get_update_method(schema_version)
+    schema_metadata = get_versions().get(schema_version)
+    update_method = schema_metadata.update_method if schema_metadata else None
     if not update_method:
         raise GraphSchemaError(schema_version)
 
@@ -87,34 +86,21 @@ def update_graph_schema(graph: networkx.DiGraph):
             raise RuntimeError("graph conversion did not increment the schema version")
 
 
-def _get_update_method(
-    schema_version: Version,
-) -> Optional[Callable[[networkx.DiGraph], None]]:
-    try:
-        mod = importlib.import_module(
-            __name__ + ".v" + str(schema_version).replace(".", "_")
-        )
-    except ImportError:
-        return None
-    return mod.update_graph_schema
-
-
 class GraphSchemaError(ValueError):
     def __init__(self, schema_version: Version) -> None:
-        lbound, ubound = get_version_bounds().get(schema_version, (None, None))
-        if lbound and ubound:
-            return super().__init__(
-                f'Graph schema version "{schema_version}" requires another library version: python3 -m pip install "ewokscore>={lbound},<{ubound}"`'
-            )
-        elif lbound:
-            return super().__init__(
-                f'Graph schema version "{schema_version}" requires another library version: python3 -m pip install "ewokscore>={lbound}"'
-            )
-        elif ubound:
-            return super().__init__(
-                f'Graph schema version "{schema_version}" requires another library version: python3 -m pip install "ewokscore<{ubound}"'
-            )
-        else:
+        version_metadata = get_versions().get(schema_version)
+
+        if not version_metadata:
             return super().__init__(
                 f'Graph schema version "{schema_version}" is either invalid or requires a newer library version: python3 -m pip install --upgrade ewokscore'
             )
+        lbound, ubound = version_metadata.ewokscore_bounds
+
+        if not ubound:
+            return super().__init__(
+                f'Graph schema version "{schema_version}" requires another library version: python3 -m pip install "ewokscore>={lbound}"'
+            )
+
+        return super().__init__(
+            f'Graph schema version "{schema_version}" requires another library version: python3 -m pip install "ewokscore>={lbound},<{ubound}"`'
+        )

--- a/src/ewokscore/graph/schema/metadata.py
+++ b/src/ewokscore/graph/schema/metadata.py
@@ -1,0 +1,24 @@
+from typing import Callable, Optional, Tuple
+from packaging.version import parse as parse_version
+import networkx
+
+
+class SchemaMetadata:
+    """
+    Metadata associated to each schema version:
+
+        - ewokscore bounds: Versions of ewokscore that support this schema version
+        - update method: A function that updates this schema version to the next one
+    """
+
+    def __init__(
+        self,
+        ewokscore_bounds: Tuple[str, Optional[str]],
+        update_method: Optional[Callable[[networkx.DiGraph], None]],
+    ) -> None:
+        lower, upper = ewokscore_bounds
+        if upper:
+            self.ewokscore_bounds = parse_version(lower), parse_version(upper)
+        else:
+            self.ewokscore_bounds = parse_version(lower), None
+        self.update_method = update_method

--- a/src/ewokscore/graph/schema/update.py
+++ b/src/ewokscore/graph/schema/update.py
@@ -1,0 +1,11 @@
+import networkx
+
+
+def v0_update(graph: networkx.DiGraph) -> None:
+    """Outdated version"""
+    raise RuntimeError("not supported")
+
+
+def from_v1_0_to_v1_1(graph: networkx.DiGraph) -> None:
+    """This version does not have the requirements field."""
+    graph.graph["schema_version"] = "1.1"

--- a/src/ewokscore/graph/schema/v0_0.py
+++ b/src/ewokscore/graph/schema/v0_0.py
@@ -1,6 +1,0 @@
-import networkx
-
-
-def update_graph_schema(graph: networkx.DiGraph) -> None:
-    """This version is for testing"""
-    raise RuntimeError("not supported")

--- a/src/ewokscore/graph/schema/v0_1.py
+++ b/src/ewokscore/graph/schema/v0_1.py
@@ -1,6 +1,0 @@
-import networkx
-
-
-def update_graph_schema(graph: networkx.DiGraph) -> None:
-    """This version is for testing"""
-    pass

--- a/src/ewokscore/graph/schema/v0_2.py
+++ b/src/ewokscore/graph/schema/v0_2.py
@@ -1,6 +1,0 @@
-import networkx
-
-
-def update_graph_schema(graph: networkx.DiGraph) -> None:
-    """This version is for testing"""
-    graph.graph["schema_version"] = "1.0"

--- a/src/ewokscore/graph/schema/v0_3.py
+++ b/src/ewokscore/graph/schema/v0_3.py
@@ -1,6 +1,0 @@
-import networkx
-
-
-def update_graph_schema(graph: networkx.DiGraph) -> None:
-    """This version is for testing"""
-    graph.graph["schema_version"] = "0.1"

--- a/src/ewokscore/graph/schema/v1_0.py
+++ b/src/ewokscore/graph/schema/v1_0.py
@@ -1,6 +1,0 @@
-import networkx
-
-
-def update_graph_schema(graph: networkx.DiGraph) -> None:
-    """This version does not have the requirements field."""
-    graph.graph["schema_version"] = "1.1"

--- a/src/ewokscore/tests/conftest.py
+++ b/src/ewokscore/tests/conftest.py
@@ -2,6 +2,9 @@ import pytest
 from jupyter_client.kernelspec import KernelSpecManager
 from ipykernel.kernelspec import install as install_kernel
 
+from packaging.version import parse as parse_version
+from ewokscore.graph.schema import SchemaMetadata, get_versions
+
 
 @pytest.fixture
 def varinfo(tmpdir):
@@ -15,3 +18,29 @@ def testkernel():
     install_kernel(kernel_name=kernel_name, user=True)
     yield kernel_name
     m.remove_kernel_spec(kernel_name)
+
+
+@pytest.fixture
+def use_test_schema_versions(monkeypatch):
+    from ewokscore.graph import schema
+
+    def no_update(graph):
+        pass
+
+    def backward_update(graph):
+        graph.graph["schema_version"] = "0.1"
+
+    def update_from_v0_2_to_1_0(graph):
+        graph.graph["schema_version"] = "1.0"
+
+    def get_test_versions():
+        return {
+            parse_version("0.1"): SchemaMetadata(("0.1.0-rc", None), no_update),
+            parse_version("0.2"): SchemaMetadata(
+                ("0.1.0-rc", None), update_from_v0_2_to_1_0
+            ),
+            parse_version("0.3"): SchemaMetadata(("0.1.0-rc", None), backward_update),
+            **get_versions(),
+        }
+
+    monkeypatch.setattr(schema, "get_versions", get_test_versions)

--- a/src/ewokscore/tests/test_graph_schema.py
+++ b/src/ewokscore/tests/test_graph_schema.py
@@ -1,7 +1,8 @@
 import pytest
 import logging
 from ewokscore.graph import load_graph
-from ewokscore.graph.schema import LATEST_VERSION, get_version_bounds
+from ewokscore.graph.schema import LATEST_VERSION, get_versions
+
 
 LATEST_VERSION = str(LATEST_VERSION)
 
@@ -22,11 +23,12 @@ def test_graph_version(caplog):
     # Update of the latest version
     assert_load({"graph": {"id": "test", "schema_version": LATEST_VERSION}})
 
-    # Correct update method
+
+def test_correct_update_method(use_test_schema_versions):
     assert_load({"graph": {"id": "test", "schema_version": "0.2"}})
 
 
-def test_error_on_improper_update_methods():
+def test_error_on_improper_update_methods(use_test_schema_versions):
     # Update method which does not change the version
     with pytest.raises(
         RuntimeError,
@@ -54,5 +56,5 @@ def assert_load(adict: dict):
     assert load_graph(adict).graph.graph["schema_version"] == LATEST_VERSION
 
 
-def assert_version_bounds():
-    assert LATEST_VERSION in get_version_bounds()
+def assert_latest_version_exists():
+    assert LATEST_VERSION in get_versions()


### PR DESCRIPTION
***In GitLab by @loichuder on Oct 11, 2024, 13:05 GMT+2:***

By schema version metadata, I mean the **ewokscore bounds** and the **update method**. This metadata is now stored in a dictionary with schema versions as keys. This means we don't have to rely on dynamic imports since the update methods are now explicitly declared for each schema version.

Also, I took this opportunity to remove the test schema versions from the actual "real" code and make the tests rely on a monkeypatching fixture instead.

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/249*