### PR TITLE
Bump to version 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.12.0
+
+- Python 3.12.5+: accommodate for `urllib` change of relative paths.
+
 ## 0.11.0
 
 - Add support for latest `networkx` version (>="3.4rc0")

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"


### PR DESCRIPTION
***In GitLab by @loichuder on Oct 15, 2024, 08:30 GMT+2:***



**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/253*