### PR TITLE
support numpy 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Remove upper bound on `numpy`
+
 ## 0.12.0
 
 - Python 3.12.5+: accommodate for `urllib` change of relative paths.

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ package_dir=
 packages=find:
 python_requires = >=3.6
 install_requires = 
-    numpy >=1.15,<2
+    numpy >=1.15
     networkx >=2
     silx >=1
     pyyaml >=5.1


### PR DESCRIPTION
***In GitLab by @woutdenolf on Oct 15, 2024, 18:36 GMT+2:***

We pinned numpy because of h5py: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/222

This MR unpins it.

**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/254*