### PR TITLE
bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.13.0
+
 - Remove upper bound on `numpy`
 
 ## 0.12.0

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.12.0"
+__version__ = "0.13.0"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Oct 16, 2024, 09:34 GMT+2:***



**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/255*