### PR TITLE
Bump to version 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 0.13.1
+
+- Fix wrong task type when discovering `ppfmethod` tasks
+
 ## 0.13.0
 
 - Remove upper bound on `numpy`

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.13.0"
+__version__ = "0.13.1"


### PR DESCRIPTION
***In GitLab by @loichuder on Oct 23, 2024, 16:55 GMT+2:***



**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/257*