### PR TITLE
add optional time profiling

### DIFF
--- a/src/ewokscore/graph/execute/sequential.py
+++ b/src/ewokscore/graph/execute/sequential.py
@@ -26,7 +26,7 @@ def instantiate_task_static(
     tasks: Optional[Dict[Task, int]] = None,
     varinfo: Optional[dict] = None,
     execinfo: Optional[dict] = None,
-    profile_directory: Optional[str] = None,
+    task_options: Optional[dict] = None,
     evict_result_counter: Optional[Dict[NodeIdType, int]] = None,
 ) -> Task:
     """Instantiate destination task while no access to the dynamic inputs.
@@ -49,7 +49,7 @@ def instantiate_task_static(
                 tasks=tasks,
                 varinfo=varinfo,
                 execinfo=execinfo,
-                profile_directory=profile_directory,
+                task_options=task_options,
                 evict_result_counter=evict_result_counter,
             )
         link_attrs = graph[source_id][node_id]
@@ -72,7 +72,7 @@ def instantiate_task_static(
         inputs=dynamic_inputs,
         varinfo=varinfo,
         execinfo=execinfo,
-        profile_directory=profile_directory,
+        task_options=task_options,
     )
     tasks[node_id] = target_task
     return target_task
@@ -89,7 +89,7 @@ def execute_graph(
     graph: networkx.DiGraph,
     varinfo: Optional[dict] = None,
     execinfo: Optional[dict] = None,
-    profile_directory: Optional[str] = None,
+    task_options: Optional[dict] = None,
     raise_on_error: Optional[bool] = True,
     outputs: Optional[List[dict]] = None,
     merge_outputs: Optional[bool] = True,
@@ -125,7 +125,7 @@ def execute_graph(
                 tasks=tasks,
                 varinfo=varinfo,
                 execinfo=execinfo,
-                profile_directory=profile_directory,
+                task_options=task_options,
                 evict_result_counter=evict_result_counter,
             )
             task.execute(

--- a/src/ewokscore/inittask.py
+++ b/src/ewokscore/inittask.py
@@ -121,7 +121,7 @@ def instantiate_task(
     inputs: Optional[dict] = None,
     varinfo: Optional[dict] = None,
     execinfo: Optional[dict] = None,
-    profile_directory: Optional[str] = None,
+    task_options: Optional[dict] = None,
 ) -> Task:
     """
     :param node_id:
@@ -140,14 +140,17 @@ def instantiate_task(
 
     # Instantiate task
     task_type, task_info = task_executable_info(node_id, node_attrs)
-    task_kwargs = {
-        "inputs": task_inputs,
-        "varinfo": varinfo,
-        "node_id": node_id,
-        "node_attrs": node_attrs,
-        "execinfo": execinfo,
-        "profile_directory": profile_directory,
-    }
+    if task_options:
+        task_kwargs = dict(task_options)
+    else:
+        task_kwargs = dict()
+    task_kwargs.update(
+        inputs=task_inputs,
+        varinfo=varinfo,
+        node_id=node_id,
+        node_attrs=node_attrs,
+        execinfo=execinfo,
+    )
     if task_type == "class":
         return Task.instantiate(task_info["task_identifier"], **task_kwargs)
 

--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -48,7 +48,7 @@ class Task(Registered, UniversalHashable, register=False):
         node_id: Optional[node.NodeIdType] = None,
         node_attrs: Optional[dict] = None,
         execinfo: Optional[dict] = None,
-        profile_directory: Optional[str] = None,
+        profile_directory: Optional[dict] = None,
     ):
         """The named arguments are inputs and Variable configuration"""
         if inputs is None:
@@ -93,7 +93,7 @@ class Task(Registered, UniversalHashable, register=False):
         self.__exception = None
         self.__succeeded = None
         self._cancelled = False
-        self._profile_directory = profile_directory
+        self._profile_directory = profile_directory or dict()
 
         # The output hash will update dynamically if any of the input
         # variables change


### PR DESCRIPTION
***In GitLab by @woutdenolf on Nov 2, 2024, 19:13 GMT+1:***

The other bindings will use this as well: https://gitlab.esrf.fr/workflow/ewoks/ewoksorange/-/merge_requests/189, https://gitlab.esrf.fr/workflow/ewoks/ewoksppf/-/merge_requests/104, https://gitlab.esrf.fr/workflow/ewoks/ewoksdask/-/merge_requests/62, https://gitlab.esrf.fr/workflow/ewoks/ewoks/-/merge_requests/182

@LudoBroche We will use this for MX time profiling.

@loichuder Alternatively we could introduce `task_options` (or `taskinfo` like `varinfo` and `execinfo`) so that when we need to pass additional task arguments in the future like `profile_directory`, we don't need to adapt all engines. What do you think?

**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/258*