### PR TITLE
Harmonize task_type arg of discovery functions

### DIFF
--- a/src/ewokscore/task_discovery.py
+++ b/src/ewokscore/task_discovery.py
@@ -38,23 +38,32 @@ logger = logging.getLogger(__name__)
 
 def discover_tasks_from_modules(
     *module_names: str,
-    task_type="class",
+    task_type: Optional[str] = None,
     reload: bool = False,
     raise_import_failure: bool = True,
 ) -> List[TaskDict]:
-    return list(
-        iter_discover_tasks_from_modules(
-            *module_names,
-            task_type=task_type,
-            reload=reload,
-            raise_import_failure=raise_import_failure,
+    if task_type is None:
+        task_types = ("class", "ppfmethod", "method")
+    else:
+        task_types = (task_type,)
+
+    result = list()
+    for task_type in task_types:
+        result.extend(
+            _iter_discover_tasks_from_modules(
+                *module_names,
+                task_type=task_type,
+                reload=reload,
+                raise_import_failure=raise_import_failure,
+            )
         )
-    )
+
+    return result
 
 
-def iter_discover_tasks_from_modules(
+def _iter_discover_tasks_from_modules(
     *module_names: str,
-    task_type="class",
+    task_type: str,
     reload: bool = False,
     raise_import_failure: bool = True,
 ) -> Generator[TaskDict, None, None]:
@@ -78,7 +87,7 @@ def iter_discover_tasks_from_modules(
             )
         yield from _iter_registered_tasks(*module_names)
     else:
-        raise ValueError("Class type does not support discovery")
+        raise ValueError(f"Task type {task_type} does not support discovery")
 
 
 def _iter_registered_tasks(*filter_modules: str) -> Generator[TaskDict, None, None]:
@@ -152,11 +161,18 @@ def _iter_ppfmethod_tasks(
             }
 
 
-def iter_discover_all_tasks(
-    reload: bool = False, raise_import_failure: bool = False
+def _iter_discover_all_tasks(
+    reload: bool = False,
+    task_type: Optional[str] = None,
+    raise_import_failure: bool = False,
 ) -> Generator[TaskDict, None, None]:
     visited = set()
-    for task_type in ("class", "ppfmethod", "method"):
+    if task_type is None:
+        task_types = ("class", "ppfmethod", "method")
+    else:
+        task_types = (task_type,)
+
+    for task_type in task_types:
         group = "ewoks.tasks." + task_type
         for entrypoint in iter_entry_points(group):
             module_pattern = entrypoint.name
@@ -166,7 +182,7 @@ def iter_discover_all_tasks(
             for module_name in _iter_modules_from_pattern(
                 module_pattern, reload=reload, raise_import_failure=raise_import_failure
             ):
-                yield from iter_discover_tasks_from_modules(
+                yield from _iter_discover_tasks_from_modules(
                     module_name,
                     task_type=task_type,
                     reload=reload,
@@ -175,11 +191,15 @@ def iter_discover_all_tasks(
 
 
 def discover_all_tasks(
-    reload: bool = False, raise_import_failure: bool = False
+    reload: bool = False,
+    task_type: Optional[str] = None,
+    raise_import_failure: bool = False,
 ) -> List[TaskDict]:
     return list(
-        iter_discover_all_tasks(
-            reload=reload, raise_import_failure=raise_import_failure
+        _iter_discover_all_tasks(
+            reload=reload,
+            task_type=task_type,
+            raise_import_failure=raise_import_failure,
         )
     )
 

--- a/src/ewokscore/tests/test_task_discovery.py
+++ b/src/ewokscore/tests/test_task_discovery.py
@@ -1,34 +1,69 @@
 from ewokscore import task_discovery
 
+CLASS_TASKS = [
+    {
+        "task_type": "class",
+        "task_identifier": "ewokscore.tests.discover_module.MyTask1",
+        "required_input_names": ["a"],
+        "optional_input_names": ["b"],
+        "output_names": ["result"],
+        "category": "ewokscore",
+        "description": "Test 1",
+    },
+    {
+        "task_type": "class",
+        "task_identifier": "ewokscore.tests.discover_module.MyTask2",
+        "required_input_names": ["a"],
+        "optional_input_names": ["b"],
+        "output_names": ["result"],
+        "category": "ewokscore",
+        "description": None,
+    },
+]
+
+METHOD_TASKS = [
+    {
+        "task_type": "method",
+        "task_identifier": "ewokscore.tests.discover_module.run",
+        "required_input_names": ["a"],
+        "optional_input_names": ["b"],
+        "output_names": ["return_value"],
+        "category": "ewokscore",
+        "description": "Test 2",
+    },
+    {
+        "task_type": "method",
+        "task_identifier": "ewokscore.tests.discover_module.myfunc",
+        "required_input_names": ["a"],
+        "optional_input_names": ["b"],
+        "output_names": ["return_value"],
+        "category": "ewokscore",
+        "description": None,
+    },
+]
+
+PPFMETHOD_TASKS = [
+    {
+        "task_type": "ppfmethod",
+        "task_identifier": "ewokscore.tests.discover_module.run",
+        "required_input_names": ["a"],
+        "optional_input_names": ["b"],
+        "output_names": ["return_value"],
+        "category": "ewokscore",
+        "description": "Test 2",
+    },
+]
+
 
 def test_task_class_discovery():
-    expected = [
-        {
-            "task_type": "class",
-            "task_identifier": "ewokscore.tests.discover_module.MyTask1",
-            "required_input_names": ["a"],
-            "optional_input_names": ["b"],
-            "output_names": ["result"],
-            "category": "ewokscore",
-            "description": "Test 1",
-        },
-        {
-            "task_type": "class",
-            "task_identifier": "ewokscore.tests.discover_module.MyTask2",
-            "required_input_names": ["a"],
-            "optional_input_names": ["b"],
-            "output_names": ["result"],
-            "category": "ewokscore",
-            "description": None,
-        },
-    ]
+    expected = CLASS_TASKS
 
     tasks = task_discovery.discover_tasks_from_modules()
     for task in expected:
         assert task not in tasks
 
     tasks = task_discovery.discover_tasks_from_modules(
-        "ewokscore.tests.discover_module"
+        "ewokscore.tests.discover_module", task_type="class"
     )
     assert_tasks(tasks, expected)
     assert len(tasks) == len(expected)
@@ -38,26 +73,7 @@ def test_task_class_discovery():
 
 
 def test_task_method_discovery():
-    expected = [
-        {
-            "task_type": "method",
-            "task_identifier": "ewokscore.tests.discover_module.run",
-            "required_input_names": ["a"],
-            "optional_input_names": ["b"],
-            "output_names": ["return_value"],
-            "category": "ewokscore",
-            "description": "Test 2",
-        },
-        {
-            "task_type": "method",
-            "task_identifier": "ewokscore.tests.discover_module.myfunc",
-            "required_input_names": ["a"],
-            "optional_input_names": ["b"],
-            "output_names": ["return_value"],
-            "category": "ewokscore",
-            "description": None,
-        },
-    ]
+    expected = METHOD_TASKS
     tasks = task_discovery.discover_tasks_from_modules(
         "ewokscore.tests.discover_module", task_type="method"
     )
@@ -66,17 +82,8 @@ def test_task_method_discovery():
 
 
 def test_task_ppfmethod_discovery():
-    expected = [
-        {
-            "task_type": "ppfmethod",
-            "task_identifier": "ewokscore.tests.discover_module.run",
-            "required_input_names": ["a"],
-            "optional_input_names": ["b"],
-            "output_names": ["return_value"],
-            "category": "ewokscore",
-            "description": "Test 2",
-        }
-    ]
+    expected = PPFMETHOD_TASKS
+
     tasks = task_discovery.discover_tasks_from_modules(
         "ewokscore.tests.discover_module", task_type="ppfmethod"
     )
@@ -84,7 +91,16 @@ def test_task_ppfmethod_discovery():
     assert len(tasks) == len(expected)
 
 
-def test_task_discovery():
+def test_task_all_types_discovery():
+    expected = [*CLASS_TASKS, *METHOD_TASKS, *PPFMETHOD_TASKS]
+    tasks = task_discovery.discover_tasks_from_modules(
+        "ewokscore.tests.discover_module"
+    )
+    assert_tasks(tasks, expected)
+    assert len(tasks) == len(expected)
+
+
+def test_all_tasks_discovery():
     expected = [
         {
             "category": "ewokscore",
@@ -162,6 +178,12 @@ def test_task_discovery():
 
     tasks = task_discovery.discover_all_tasks()
     assert_tasks(tasks, expected)
+
+    for task_type in ("class", "method", "ppfmethod"):
+        tasks = task_discovery.discover_all_tasks(task_type=task_type)
+        assert_tasks(
+            tasks, [task for task in expected if task["task_type"] == task_type]
+        )
 
 
 def assert_tasks(tasks, expected):


### PR DESCRIPTION
***In GitLab by @loichuder on Nov 22, 2024, 14:50 GMT+1:***

> I would propose to harmonize this by allowing to specify a task_type to both `discover_task_from_modules` and `discover_all_tasks`. 
>   - If it is not specified, it discovers "usual" types `class`, `method` and `ppfmethod` (current behaviour of `discover_all_tasks`).
>   - If it is specified, it only discovers this task type (current behaviour of `discover_task_from_modules`)
>
> https://gitlab.esrf.fr/workflow/ewoks/ewoksweb/-/issues/276#note_376446

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/260*