### PR TITLE
Bump to 0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 0.15.0
+
+Breaking changes:
+
+- By default, `discover_tasks_from_modules` now discovers tasks of type `class`, `ppfmethod` and `method` instead of only `class`.
+
+New features:
+
+- `discover_all_tasks` now accepts a `task_type` argument to only discover a specific task type. By default, it discovers tasks of type `class`, `ppfmethod` and `method`, as previously.
+
 ## 0.14.0
 
 New features:

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.14.0"
+__version__ = "0.15.0"


### PR DESCRIPTION
***In GitLab by @loichuder on Nov 28, 2024, 11:27 GMT+1:***



**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/261*