### PR TITLE
bump version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+## 1.0.0
+
 Breaking changes:
 
 - Remove deprecated `binding` argument from `execute_graph`.
+
+Bug fixes:
+
+- Fix bug in notebook task instantiation.
 
 ## 0.15.0
 

--- a/src/ewokscore/__init__.py
+++ b/src/ewokscore/__init__.py
@@ -2,4 +2,4 @@ from .task import Task  # noqa: F401
 from .taskwithprogress import TaskWithProgress  # noqa: F401
 from .bindings import *  # noqa: F403,F401
 
-__version__ = "0.15.0"
+__version__ = "1.0.0rc1"


### PR DESCRIPTION
***In GitLab by @woutdenolf on Dec 22, 2024, 15:47 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/267*