### PR TITLE
bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.1.0
+
 New features:
 
 - Support for Python 3.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ewokscore"
-version = "1.0.0"
+version = "1.1.0"
 authors = [{ name = "ESRF", email = "dau-pydev@esrf.fr" }]
 description = "API for graphs and tasks in Ewoks"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
***In GitLab by @woutdenolf on Jan 25, 2025, 12:31 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/272*