### PR TITLE
Remove fields that are not part of the Ewoks spec in `convert_graph`

### DIFF
--- a/src/ewokscore/graph/serialize.py
+++ b/src/ewokscore/graph/serialize.py
@@ -307,6 +307,11 @@ def _dict_to_networkx(graph: dict) -> networkx.DiGraph:
 
 def _networkx_to_dict(graph: networkx.DiGraph) -> dict:
     if network_x_version < Version("3.4rc"):
-        return networkx.readwrite.json_graph.node_link_data(graph)
+        graph_dict = networkx.readwrite.json_graph.node_link_data(graph)
     else:
-        return networkx.readwrite.json_graph.node_link_data(graph, edges="links")
+        graph_dict = networkx.readwrite.json_graph.node_link_data(graph, edges="links")
+
+    # Remove fields that are not part of the Ewoks spec
+    graph_dict.pop("directed")
+    graph_dict.pop("multigraph")
+    return graph_dict


### PR DESCRIPTION
***In GitLab by @loichuder on Feb 20, 2025, 15:36 GMT+1:***

Fix #53

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/279*