### PR TITLE
Allow to specify a pydantic model to validate task inputs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "packaging",
     "ewoksutils >=1.2.0",
     "importlib_metadata;python_version < '3.9'",
+    "pydantic >= 2",
 ]
 
 [project.urls]

--- a/src/ewokscore/model.py
+++ b/src/ewokscore/model.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class BaseInputModel(BaseModel, arbitrary_types_allowed=True):
+    pass

--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -1,22 +1,24 @@
+import cProfile
 import os
+import random
 import re
 import time
-import random
 import warnings
-import cProfile
-from typing import Any, Optional, Union, Mapping, Generator
-from contextlib import ExitStack
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
+from typing import Any, Generator, Mapping, Optional, Set, Tuple, Type, Union
 
+from pydantic import ValidationError
+
+from . import events, missing_data, node
 from .hashing import UniversalHashable
+from .model import BaseInputModel
 from .registration import Registered
-from .variable import VariableContainer
-from .variable import VariableContainerNamespace
-from .variable import ReadOnlyVariableContainerNamespace
-from .variable import VariableContainerMissingNamespace
-from . import node
-from . import missing_data
-from . import events
+from .variable import (
+    ReadOnlyVariableContainerNamespace,
+    VariableContainer,
+    VariableContainerMissingNamespace,
+    VariableContainerNamespace,
+)
 
 
 class TaskInputError(ValueError):
@@ -36,10 +38,11 @@ class Task(Registered, UniversalHashable, register=False):
     done with `ewokscore.inittask.instantiate_task`.
     """
 
-    _INPUT_NAMES = set()
-    _OPTIONAL_INPUT_NAMES = set()
-    _OUTPUT_NAMES = set()
-    _N_REQUIRED_POSITIONAL_INPUTS = 0
+    _INPUT_NAMES: Set[str] = set()
+    _OPTIONAL_INPUT_NAMES: Set[str] = set()
+    _OUTPUT_NAMES: Set[str] = set()
+    _N_REQUIRED_POSITIONAL_INPUTS: int = 0
+    _INPUT_MODEL: Union[Type[BaseInputModel], None] = None
 
     def __init__(
         self,
@@ -56,23 +59,7 @@ class Task(Registered, UniversalHashable, register=False):
         elif not isinstance(inputs, Mapping):
             raise TypeError(inputs, type(inputs))
 
-        # Check required inputs
-        missing_required = set(self._INPUT_NAMES) - set(inputs.keys())
-        if missing_required:
-            raise TaskInputError(f"Missing inputs for {type(self)}: {missing_required}")
-
-        # Check required positional inputs
-        nrequiredargs = self._N_REQUIRED_POSITIONAL_INPUTS
-        for i in range(nrequiredargs):
-            if i not in inputs and str(i) not in inputs:
-                raise TaskInputError(
-                    f"Missing inputs for {type(self)}: positional argument #{i}"
-                )
-
-        # Init missing optional inputs
-        missing_optional = set(self._OPTIONAL_INPUT_NAMES) - set(inputs.keys())
-        for varname in missing_optional:
-            inputs[varname] = self.MISSING_DATA
+        inputs = self._check_inputs(inputs)
 
         # Required outputs for the task to be "done"
         ovars = {varname: self.MISSING_DATA for varname in self._OUTPUT_NAMES}
@@ -98,6 +85,12 @@ class Task(Registered, UniversalHashable, register=False):
         # The output hash will update dynamically if any of the input
         # variables change
         varinfo = node.get_varinfo(node_attrs, varinfo)
+        # varinfo and input models do not work together for now
+        if varinfo and self._INPUT_MODEL is not None:
+            raise TypeError(
+                "Cannot use varinfo if a task uses an input_model. Remove varinfo or use input_names instead of a model."
+            )
+
         self.__inputs = VariableContainer(value=inputs, varinfo=varinfo)
         self.__outputs = VariableContainer(
             value=ovars,
@@ -119,23 +112,57 @@ class Task(Registered, UniversalHashable, register=False):
         # The task class has the same hash as its output
         super().__init__(pre_uhash=self.__outputs)
 
+    def _check_inputs(self, inputs: Mapping) -> Mapping:
+        if self._INPUT_MODEL:
+            try:
+                validated_inputs = self._INPUT_MODEL(**inputs)
+            except ValidationError as e:
+                raise TaskInputError(e) from e
+            return validated_inputs.model_dump()
+
+        # Check required inputs
+        missing_required = set(self._INPUT_NAMES) - set(inputs.keys())
+        if missing_required:
+            raise TaskInputError(f"Missing inputs for {type(self)}: {missing_required}")
+
+        # Check required positional inputs
+        nrequiredargs = self._N_REQUIRED_POSITIONAL_INPUTS
+        for i in range(nrequiredargs):
+            if i not in inputs and str(i) not in inputs:
+                raise TaskInputError(
+                    f"Missing inputs for {type(self)}: positional argument #{i}"
+                )
+
+        # Init missing optional inputs
+        missing_optional = set(self._OPTIONAL_INPUT_NAMES) - set(inputs.keys())
+        for varname in missing_optional:
+            inputs[varname] = self.MISSING_DATA
+
+        return inputs
+
     def __init_subclass__(
         subclass,
-        input_names=tuple(),
-        optional_input_names=tuple(),
-        output_names=tuple(),
-        n_required_positional_inputs=0,
+        input_names: Tuple[str, ...] = tuple(),
+        optional_input_names: Tuple[str, ...] = tuple(),
+        output_names: Tuple[str, ...] = tuple(),
+        n_required_positional_inputs: int = 0,
+        input_model: Union[Type[BaseInputModel], None] = None,
         **kwargs,
     ):
         super().__init_subclass__(**kwargs)
-        input_names = set(input_names)
-        optional_input_names = set(optional_input_names)
-        output_names = set(output_names)
+
+        input_names_set, optional_input_names_set = subclass._generate_inputs_sets(
+            input_names,
+            optional_input_names,
+            n_required_positional_inputs,
+            input_model,
+        )
+        output_names_set = set(output_names)
 
         reserved = subclass._reserved_variable_names()
-        forbidden = input_names & reserved
-        forbidden |= optional_input_names & reserved
-        forbidden |= output_names & reserved
+        forbidden = input_names_set & reserved
+        forbidden |= optional_input_names_set & reserved
+        forbidden |= output_names_set & reserved
         if forbidden:
             raise RuntimeError(
                 "The following names cannot be used a variable names: "
@@ -143,12 +170,72 @@ class Task(Registered, UniversalHashable, register=False):
             )
 
         # Ensures that each subclass has their own sets:
-        subclass._INPUT_NAMES = subclass._INPUT_NAMES | set(input_names)
-        subclass._OPTIONAL_INPUT_NAMES = subclass._OPTIONAL_INPUT_NAMES | set(
-            optional_input_names
+        subclass._INPUT_NAMES = subclass._INPUT_NAMES | input_names_set
+        subclass._OPTIONAL_INPUT_NAMES = (
+            subclass._OPTIONAL_INPUT_NAMES | optional_input_names_set
         )
-        subclass._OUTPUT_NAMES = subclass._OUTPUT_NAMES | set(output_names)
+        subclass._OUTPUT_NAMES = subclass._OUTPUT_NAMES | output_names_set
         subclass._N_REQUIRED_POSITIONAL_INPUTS = n_required_positional_inputs
+        subclass._INPUT_MODEL = input_model
+
+    @classmethod
+    def _generate_inputs_sets(
+        subclass,
+        input_names: Tuple[str, ...],
+        optional_input_names: Tuple[str, ...],
+        n_required_positional_inputs: int,
+        input_model: Union[BaseInputModel, None],
+    ) -> Tuple[Set[str], Set[str]]:
+        if input_model is None:
+            input_names_set = set(input_names)
+            optional_input_names_set = set(optional_input_names)
+
+            has_input_names = bool(
+                input_names_set
+                or optional_input_names_set
+                or n_required_positional_inputs > 0
+            )
+            if has_input_names and subclass._INPUT_MODEL is not None:
+                raise TypeError(
+                    f"""Cannot use input_names or optional_input_names since the original task {subclass} uses a input model.
+                    Specify inputs via a subclass of the original task input model."""
+                )
+
+            return input_names_set, optional_input_names_set
+
+        if not issubclass(input_model, BaseInputModel):
+            raise TypeError(
+                "input_model should be a subclass of ewokscore.model.BaseInputModel"
+            )
+
+        if input_names or optional_input_names or n_required_positional_inputs:
+            raise TypeError(
+                "input_model cannot be used with input_names, optional_input_names or n_required_positional_inputs. Please use one or the other"
+            )
+
+        subclass_has_input_names = bool(
+            subclass._INPUT_NAMES
+            or subclass._OPTIONAL_INPUT_NAMES
+            or subclass._N_REQUIRED_POSITIONAL_INPUTS > 0
+        )
+        if subclass_has_input_names and subclass._INPUT_MODEL is None:
+            raise TypeError(
+                f"""Cannot use input_model since the original task {subclass} uses input_names and/or n_required_positional_inputs.
+                Specify inputs via a input_names or optional_input_names."""
+            )
+
+        if subclass._INPUT_MODEL is not None and not issubclass(
+            input_model, subclass._INPUT_MODEL
+        ):
+            raise TypeError(
+                f"Input model {input_model} from task subclass must be a subclass of the original task input model {subclass._INPUT_MODEL}"
+            )
+
+        fields = input_model.model_fields
+        return (
+            set(name for name, field in fields.items() if field.is_required()),
+            set(name for name, field in fields.items() if not field.is_required()),
+        )
 
     @staticmethod
     def _reserved_variable_names():

--- a/src/ewokscore/tests/test_task_model.py
+++ b/src/ewokscore/tests/test_task_model.py
@@ -1,0 +1,159 @@
+from typing import Union
+
+import pytest
+
+from ewokscore.missing_data import MISSING_DATA, MissingData, is_missing_data
+from ewokscore.model import BaseInputModel
+from ewokscore.task import Task, TaskInputError
+
+from .examples.tasks.sumtask import SumTask
+
+
+class User(BaseInputModel):
+    id: int
+    name: str = "Jane Doe"
+
+
+class PassThroughTask(Task, input_model=User, output_names=["result"]):
+    def run(self):
+        self.outputs.result = self.get_input_values()
+
+
+def test_error_if_input_model_does_not_derive_from_base_model():
+    from pydantic import BaseModel
+
+    class WrongBaseModelUser(BaseModel):
+        id: int
+        name: str = "Jane Doe"
+
+    with pytest.raises(
+        TypeError,
+        match=r"input_model should be a subclass of ewokscore.model.BaseInputModel",
+    ):
+
+        class WrongPassThroughTask(Task, input_model=WrongBaseModelUser):
+            pass
+
+
+def test_error_if_input_model_used_with_input_names():
+    with pytest.raises(TypeError, match="input_model cannot be used with input_names"):
+
+        class WrongPassThroughTask(
+            Task, input_model=User, input_names=["age"], output_names=["result"]
+        ):
+            pass
+
+
+def test_validation():
+    with pytest.raises(TaskInputError, match=r"id(\s*)Field required"):
+        PassThroughTask(inputs={})
+
+    with pytest.raises(TaskInputError, match=r"id(\s*)Input should be a valid integer"):
+        PassThroughTask(inputs={"id": "ff"})
+
+
+def test_error_if_input_model_used_with_persistence():
+    with pytest.raises(
+        TypeError, match="Cannot use varinfo if a task uses an input_model"
+    ):
+        PassThroughTask(inputs={"id": 0}, varinfo={"root_uri": None})
+
+
+def test_default_value():
+    task = PassThroughTask(inputs={"id": 5})
+    assert task.get_input_values() == {"id": 5, "name": "Jane Doe"}
+
+
+def test_run():
+    task = PassThroughTask(inputs={"id": 5, "name": "Smith"})
+    task.execute()
+    assert task.outputs["result"] == {"id": 5, "name": "Smith"}
+
+
+def test_error_on_subclass_with_wrong_submodel():
+    class Car(BaseInputModel):
+        wheels: int
+
+    with pytest.raises(
+        TypeError,
+        match="Input model (.*) from task subclass must be a subclass of the original task input model",
+    ):
+
+        class PassThroughCarTask(PassThroughTask, input_model=Car):
+            pass
+
+
+def test_error_on_subclass_with_input_names():
+    with pytest.raises(
+        TypeError,
+        match="Cannot use input_names or optional_input_names",
+    ):
+
+        class ChildPassThroughTask(PassThroughTask, input_names=["age"]):
+            pass
+
+
+def test_error_on_subclass_with_input_model_if_input_names():
+    with pytest.raises(
+        TypeError,
+        match="Cannot use input_model",
+    ):
+
+        class ChildPassThroughTask(SumTask, input_model=User):
+            pass
+
+
+def test_subclass_with_no_change():
+    class ChildPassThroughTask(PassThroughTask):
+        pass
+
+    task = ChildPassThroughTask(inputs={"id": 5, "name": "Smith"})
+    task.execute()
+    assert task.outputs["result"] == {"id": 5, "name": "Smith"}
+
+
+class SuperUser(User):
+    age: int
+
+
+class PassThroughSubTask(PassThroughTask, input_model=SuperUser):
+    pass
+
+
+def test_subclass_validation():
+    with pytest.raises(TaskInputError, match=r"age(\s*)Field required"):
+        PassThroughSubTask(inputs={"id": 5})
+
+
+def test_subclass():
+    task = PassThroughSubTask(inputs={"id": 5, "age": 18})
+    task.execute()
+    assert task.outputs["result"] == {"id": 5, "name": "Jane Doe", "age": 18}
+
+
+def test_missing_data():
+    class RegularTask(Task, input_names=["one"], optional_input_names=["two"]):
+        pass
+
+    class Model(BaseInputModel):
+        one: int
+        two: Union[int, MissingData] = MISSING_DATA
+
+    class ModelTask(Task, input_model=Model):
+        pass
+
+    regular_task = RegularTask(inputs={"one": 1})
+    model_task = ModelTask(inputs={"one": 1})
+    assert (
+        model_task.get_input_values() == regular_task.get_input_values() == {"one": 1}
+    )
+    assert (
+        is_missing_data(model_task.get_input_value("two"))
+        == is_missing_data(regular_task.get_input_value("two"))
+        == True  # noqa: E712
+    )
+    assert (
+        model_task.missing_inputs["two"]
+        == regular_task.missing_inputs["two"]
+        == True  # noqa: E712
+    )


### PR DESCRIPTION
***In GitLab by @loichuder on Mar 17, 2025, 16:38 GMT+1:***

For #67 

I did not go all the way and added the model for outputs since the current implementation will probably trigger discussions. For example, I disallow to use of `input_names`, `optional_input_names` when `input_model` is present.

**For now, the `input_model` is only used to validate inputs when instantiating tasks**. But I am quite happy for the result so far: It does not add much in terms of code in `Task` but the added value is significant in my opinion. We can even specify default values for inputs now !

## What next?

I am sure there are some of edge cases of task creation that are not handled. Perhaps you will think of them during the review but I think we need to start using the model in some of our projects for these edge cases to pop up.

Also, I feel that we can still go further: the model instance could replace the `self.inputs` container, for example. That would give proper typing! But this is on the condition that we can design something that still implements the needed features from `VariableContainer`. 

Anyway these are to be discussed later, this is out of scope for this MR.

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/280*