### PR TITLE
Add input_model field when discovering tasks

### DIFF
--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -268,6 +268,10 @@ class Task(Registered, UniversalHashable, register=False):
         return cls._OUTPUT_NAMES
 
     @classmethod
+    def input_model(cls):
+        return cls._INPUT_MODEL
+
+    @classmethod
     def class_nonce_data(cls):
         return super().class_nonce_data() + (
             sorted(cls.input_names()),

--- a/src/ewokscore/task_discovery.py
+++ b/src/ewokscore/task_discovery.py
@@ -30,7 +30,7 @@ from ewoksutils.import_utils import import_module
 
 from .task import Task
 
-TaskDict = Dict[str, Union[str, List[str]]]
+TaskDict = Dict[str, Union[str, List[str], None]]
 
 
 logger = logging.getLogger(__name__)
@@ -108,6 +108,7 @@ def _iter_registered_tasks(*filter_modules: str) -> Generator[TaskDict, None, No
             continue
         task_identifier = cls.class_registry_name()
         category = task_identifier.split(".")[0]
+        input_model = cls.input_model()
         yield {
             "task_type": "class",
             "task_identifier": task_identifier,
@@ -116,6 +117,7 @@ def _iter_registered_tasks(*filter_modules: str) -> Generator[TaskDict, None, No
             "output_names": sorted(cls.output_names()),
             "category": category,
             "description": cls.__doc__,
+            "input_model": qualname(input_model) if input_model else None,
         }
 
 
@@ -272,7 +274,7 @@ def _method_arguments(method) -> Tuple[List[str], List[str]]:
 
 def _common_method_task_fields(
     method_name: str, method_qn: FunctionType, mod: ModuleType
-) -> Dict[str, Union[str, List[str]]]:
+) -> TaskDict:
 
     task_identifier = qualname(method_qn)
     method = getattr(mod, method_name)
@@ -285,4 +287,5 @@ def _common_method_task_fields(
         "output_names": ["return_value"],
         "category": task_identifier.split(".")[0],
         "description": method.__doc__,
+        "input_model": None,
     }

--- a/src/ewokscore/tests/conftest.py
+++ b/src/ewokscore/tests/conftest.py
@@ -56,6 +56,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["result"],
             "category": "ewokscore",
             "description": "Test 1",
+            "input_model": None,
         },
         {
             "task_type": "class",
@@ -65,6 +66,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["result"],
             "category": "ewokscore",
             "description": None,
+            "input_model": None,
         },
         {
             "task_type": "class",
@@ -74,6 +76,17 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["error", "result"],
             "category": "ewokscore",
             "description": "Test 3",
+            "input_model": None,
+        },
+        {
+            "task_type": "class",
+            "task_identifier": "ewokscore.tests.discover.module2.MyTask4",
+            "required_input_names": ["a", "b"],
+            "optional_input_names": ["c", "d"],
+            "output_names": [],
+            "category": "ewokscore",
+            "description": None,
+            "input_model": "ewokscore.tests.discover.module2.Task4Inputs",
         },
     ]
 
@@ -86,6 +99,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["return_value"],
             "category": "ewokscore",
             "description": "Test 2",
+            "input_model": None,
         },
         {
             "task_type": "method",
@@ -95,6 +109,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["return_value"],
             "category": "ewokscore",
             "description": None,
+            "input_model": None,
         },
         {
             "task_type": "method",
@@ -104,6 +119,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["return_value"],
             "category": "ewokscore",
             "description": "Test",
+            "input_model": None,
         },
         {
             "task_type": "method",
@@ -113,6 +129,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["return_value"],
             "category": "ewokscore",
             "description": None,
+            "input_model": None,
         },
     ]
 
@@ -125,6 +142,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["return_value"],
             "category": "ewokscore",
             "description": "Test 2",
+            "input_model": None,
         },
         {
             "task_type": "ppfmethod",
@@ -134,6 +152,7 @@ def expected_tasks(module=None, task_type=None):
             "output_names": ["return_value"],
             "category": "ewokscore",
             "description": "Test",
+            "input_model": None,
         },
     ]
 

--- a/src/ewokscore/tests/discover/module2.py
+++ b/src/ewokscore/tests/discover/module2.py
@@ -1,4 +1,5 @@
 from ewokscore import Task
+from ewokscore.model import BaseInputModel
 
 
 class MyTask3(
@@ -19,4 +20,15 @@ def run(z, c, x=None, d=None):
 
 
 def myfunc(z, c, x=None, d=None):
+    pass
+
+
+class Task4Inputs(BaseInputModel):
+    a: int
+    b: float
+    c: int = 0
+    d: str = "DEFAULT"
+
+
+class MyTask4(Task, input_model=Task4Inputs):
     pass

--- a/src/ewokscore/tests/test_task_discovery.py
+++ b/src/ewokscore/tests/test_task_discovery.py
@@ -36,6 +36,7 @@ def test_all_tasks_discovery():
             "task_identifier": "ewokscore.tests.examples.tasks.condsumtask.CondSumTask",
             "task_type": "class",
             "description": "Check whether a value is too small",
+            "input_model": None,
         },
         {
             "category": "ewokscore",
@@ -45,6 +46,7 @@ def test_all_tasks_discovery():
             "task_identifier": "ewokscore.tests.examples.tasks.errorsumtask.ErrorSumTask",
             "task_type": "class",
             "description": "Add two number with intentional exception",
+            "input_model": None,
         },
         {
             "category": "ewokscore",
@@ -54,15 +56,18 @@ def test_all_tasks_discovery():
             "task_identifier": "ewokscore.tests.examples.tasks.nooutputtask.NoOutputTask",
             "task_type": "class",
             "description": "A task without outputs",
+            "input_model": None,
         },
         {
             "category": "ewokscore",
             "optional_input_names": ["delay"],
             "output_names": ["sum"],
             "required_input_names": ["list"],
+            "input_model": None,
             "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
             "task_type": "class",
             "description": "Add items from a list",
+            "input_model": None,
         },
         {
             "category": "ewokscore",
@@ -72,6 +77,7 @@ def test_all_tasks_discovery():
             "task_identifier": "ewokscore.tests.examples.tasks.sumtask.SumTask",
             "task_type": "class",
             "description": "Add two numbers with a delay",
+            "input_model": None,
         },
         {
             "category": "ewokscore",
@@ -81,6 +87,7 @@ def test_all_tasks_discovery():
             "optional_input_names": [],
             "output_names": ["return_value"],
             "description": "Add 1 to the first argument",
+            "input_model": None,
         },
         {
             "category": "ewokscore",
@@ -90,6 +97,7 @@ def test_all_tasks_discovery():
             "optional_input_names": [],
             "output_names": ["return_value"],
             "description": "Sum objects and add 1",
+            "input_model": None,
         },
         {
             "category": "ewokscore",
@@ -99,6 +107,7 @@ def test_all_tasks_discovery():
             "optional_input_names": [],
             "output_names": ["return_value"],
             "description": "Return positional arguments as a tuple",
+            "input_model": None,
         },
     ]
 


### PR DESCRIPTION
***In GitLab by @loichuder on Mar 20, 2025, 16:29 GMT+1:***

Contains the full qualname of the model

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/282*