### PR TITLE
Deprecated npositional_inputs in favor of n_positional_inputs

### DIFF
--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -343,6 +343,16 @@ class Task(Registered, UniversalHashable, register=False):
 
     @property
     def npositional_inputs(self):
+        """DEPRECATED"""
+        warnings.warn(
+            "the property 'npositional_inputs' is deprecated in favor of the property 'n_positional_inputs'",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.n_positional_inputs
+
+    @property
+    def n_positional_inputs(self):
         return self.__inputs.n_positional_variables
 
     @property


### PR DESCRIPTION
***In GitLab by @loichuder on Mar 26, 2025, 07:02 GMT+1:***

To be consistent with other property/class variable names where `n` is separated from the word that comes after.

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/284*