### PR TITLE
fix flake8

### DIFF
--- a/src/ewokscore/graph/schema/__init__.py
+++ b/src/ewokscore/graph/schema/__init__.py
@@ -16,11 +16,12 @@ def get_versions() -> Dict[Version, SchemaMetadata]:
     if _VERSIONS is not None:
         return _VERSIONS
 
-    return {
+    _VERSIONS = {
         parse_version("0.0"): SchemaMetadata(("0.0", "0.0.1"), v0_update),
         parse_version("1.0"): SchemaMetadata(("0.1.0-rc", None), from_v1_0_to_v1_1),
         parse_version("1.1"): SchemaMetadata(("0.1.0-rc", None), None),
     }
+    return _VERSIONS
 
 
 # Major version: increment when changing the existing schema


### PR DESCRIPTION
***In GitLab by @woutdenolf on Mar 30, 2025, 22:37 GMT+2:***

FYI @loichuder @payno @poautran @olofsvensson @LudoBroche Since flake8 version 7.2 (released this weekend) we have many projects with errors related to `nonlocal` or `global` in case we use the variable but not set it. In that case `nonlocal` or `global` is not needed and flake8 now warns about that. I fixed most of them but I ping you in case I missed some.

In this case the issue is that we are actually supposed to set the `global` but forgot.

Here is an example of unnecessary `nonlocal`: https://gitlab.esrf.fr/workflow/pypushflow/-/merge_requests/94/diffs

**Assignees:** @woutdenolf

**Reviewers:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/287*