### PR TITLE
Use deprecated from ewoksutils to mark deprecated functions/method consistently

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyyaml >=5.1",
     "h5py >=2.8",
     "packaging",
-    "ewoksutils >=1.2.0",
+    "ewoksutils >=1.3.0",
     "importlib_metadata;python_version < '3.9'",
     "pydantic >= 2",
 ]

--- a/src/ewokscore/events/global_state.py
+++ b/src/ewokscore/events/global_state.py
@@ -1,16 +1,15 @@
 """Manage the EWOKS event logger which is a global object"""
 
-import os
 import logging
-import warnings
+import os
 from contextlib import contextmanager
 from typing import Dict, Iterable, List, Optional, Tuple
 
-from ewoksutils.logging_utils.cleanup import cleanup_logger
-from ewoksutils.logging_utils.cleanup import protect_logging_state
+from ewoksutils.deprecation_utils import deprecated
 from ewoksutils.logging_utils.asyncwrapper import AsyncHandlerWrapper
+from ewoksutils.logging_utils.cleanup import cleanup_logger, protect_logging_state
 
-from .handlers import is_ewoks_event_handler, instantiate_handler
+from .handlers import instantiate_handler, is_ewoks_event_handler
 
 _app_logger = logging.getLogger(__name__)
 EWOKS_EVENT_LOGGER_NAME = f"__{__name__}__"
@@ -46,13 +45,11 @@ def add_handler(
         logger.addHandler(handler)
 
 
+@deprecated(
+    "Explicit Ewoks handler removal will be removed.",
+)
 def remove_handler(handler: logging.Handler) -> None:
     """Remove a handler from all loggers that receive EWOKS event."""
-    warnings.warn(
-        "Explicit Ewoks handler removal will be removed.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
     with _ewoks_event_logger() as logger:
         for linstance, hinstance in _iter_handler_owners(logger, handler):
             linstance.removeHandler(hinstance)

--- a/src/ewokscore/graph/serialize.py
+++ b/src/ewokscore/graph/serialize.py
@@ -1,21 +1,21 @@
-import os
 import enum
-import json
-import yaml
-import logging
-import warnings
 import importlib
-from packaging.version import Version
-from pathlib import Path
-from typing import Optional, Union, Tuple
+import json
+import logging
+import os
 from collections.abc import Mapping
+from pathlib import Path
+from typing import Optional, Tuple, Union
 
 import networkx
+import yaml
+from ewoksutils.deprecation_utils import deprecated
 from ewoksutils.path_utils import makedirs_from_filename
+from packaging.version import Version
 
 from ..node import node_id_from_json
-from .schema import normalize_schema_version
 from .models import GraphSource
+from .schema import normalize_schema_version
 
 logger = logging.getLogger(__name__)
 
@@ -232,8 +232,8 @@ def _ewoks_jsonload_hook_pair(item):
     return key, value
 
 
+@deprecated("Use 'json_load' instead")
 def ewoks_jsonload_hook(items):
-    warnings.warn("Use 'json_load' instead", DeprecationWarning)
     return _ewoks_jsonload_hook(items)
 
 

--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -3,10 +3,10 @@ import os
 import random
 import re
 import time
-import warnings
 from contextlib import ExitStack, contextmanager
 from typing import Any, Generator, Mapping, Optional, Set, Tuple, Type, Union
 
+from ewoksutils.deprecation_utils import deprecated
 from pydantic import ValidationError
 
 from . import events, missing_data, node
@@ -310,49 +310,44 @@ class Task(Registered, UniversalHashable, register=False):
         return self.__inputs.get_variable_uhashes()
 
     @property
+    @deprecated(
+        "the property 'input_values' is deprecated in favor of the function 'get_input_values'"
+    )
     def input_values(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'input_values' is deprecated in favor of the function 'get_input_values'",
-            DeprecationWarning,
-        )
         return self.get_input_values()
 
     def get_input_values(self):
         return self.__inputs.get_variable_values()
 
     @property
+    @deprecated(
+        "the property 'named_input_values' is deprecated in favor of the function 'get_named_input_values'"
+    )
     def named_input_values(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'named_input_values' is deprecated in favor of the function 'get_named_input_values'",
-            DeprecationWarning,
-        )
         return self.get_named_input_values()
 
     def get_named_input_values(self):
         return self.__inputs.get_named_variable_values()
 
     @property
+    @deprecated(
+        "the property 'positional_input_values' is deprecated in favor of the function 'get_positional_input_values'"
+    )
     def positional_input_values(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'positional_input_values' is deprecated in favor of the function 'get_positional_input_values'",
-            DeprecationWarning,
-        )
         return self.__inputs.get_positional_input_values()
 
     def get_positional_input_values(self):
         return self.__inputs.get_positional_variable_values()
 
     @property
+    @deprecated(
+        "the property 'npositional_inputs' is deprecated in favor of the property 'n_positional_inputs'"
+    )
     def npositional_inputs(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'npositional_inputs' is deprecated in favor of the property 'n_positional_inputs'",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         return self.n_positional_inputs
 
     @property
@@ -377,36 +372,33 @@ class Task(Registered, UniversalHashable, register=False):
         return self.outputs[key]
 
     @property
+    @deprecated(
+        "the property 'output_uhashes' is deprecated in favor of the function 'get_output_uhashes'"
+    )
     def output_uhashes(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'output_uhashes' is deprecated in favor of the function 'get_output_uhashes'",
-            DeprecationWarning,
-        )
         return self.get_output_uhashes()
 
     def get_output_uhashes(self):
         return self.__outputs.get_variable_uhashes()
 
     @property
+    @deprecated(
+        "the property 'output_values' is deprecated in favor of the function 'get_output_values'"
+    )
     def output_values(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'output_values' is deprecated in favor of the function 'get_output_values'",
-            DeprecationWarning,
-        )
         return self.get_output_values()
 
     def get_output_values(self):
         return self.__outputs.get_variable_values()
 
     @property
+    @deprecated(
+        "the property 'output_transfer_data' is deprecated in favor of the function 'get_output_transfer_data'"
+    )
     def output_transfer_data(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'output_transfer_data' is deprecated in favor of the function 'get_output_transfer_data'",
-            DeprecationWarning,
-        )
         return self.get_output_transfer_data()
 
     def get_output_transfer_data(self):

--- a/src/ewokscore/variable.py
+++ b/src/ewokscore/variable.py
@@ -1,13 +1,12 @@
-import warnings
-from typing import Any, Dict, Optional, Union
+from collections.abc import Iterable, Mapping, MutableMapping, Sequence
 from numbers import Integral
-from collections.abc import Mapping, MutableMapping, Iterable, Sequence
+from typing import Any, Dict, Optional, Union
 
-from . import hashing
-from . import missing_data
+from ewoksutils.deprecation_utils import deprecated
+
+from . import hashing, missing_data
 from .persistence import instantiate_data_proxy
-from .persistence.proxy import DataProxy
-from .persistence.proxy import DataUri
+from .persistence.proxy import DataProxy, DataUri
 
 
 def data_proxy_from_varinfo(
@@ -429,48 +428,44 @@ class VariableContainer(Variable, Mapping):
             v.force_non_existing()
 
     @property
+    @deprecated(
+        "the property 'variable_uhashes' is deprecated in favor of the function 'get_variable_uhashes'"
+    )
     def variable_uhashes(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'variable_uhashes' is deprecated in favor of the function 'get_variable_uhashes'",
-            DeprecationWarning,
-        )
         return self.get_variable_uhashes()
 
     def get_variable_uhashes(self):
         return {name: var.uhash for name, var in self.items()}
 
     @property
+    @deprecated(
+        "the property 'variable_values' is deprecated in favor of the function 'get_variable_values'"
+    )
     def variable_values(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'variable_values' is deprecated in favor of the function 'get_variable_values'",
-            DeprecationWarning,
-        )
         return self.get_variable_values()
 
     def get_variable_values(self):
         return {k: v.value for k, v in self.items() if not v.is_missing()}
 
     @property
+    @deprecated(
+        "the property 'variable_data_proxies' is deprecated in favor of the function 'get_variable_data_proxies'"
+    )
     def variable_data_proxies(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'variable_data_proxies' is deprecated in favor of the function 'get_variable_data_proxies'",
-            DeprecationWarning,
-        )
         return self.get_variable_data_proxies()
 
     def get_variable_data_proxies(self):
         return {k: v.data_proxy for k, v in self.items()}
 
     @property
+    @deprecated(
+        "the property 'variable_uris' is deprecated in favor of the function 'get_variable_uris'",
+    )
     def variable_uris(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'variable_uris' is deprecated in favor of the function 'get_variable_uris'",
-            DeprecationWarning,
-        )
         return self.get_variable_uris()
 
     def get_variable_uris(self):
@@ -482,12 +477,11 @@ class VariableContainer(Variable, Mapping):
         return uris
 
     @property
+    @deprecated(
+        "the property 'variable_transfer_data' is deprecated in favor of the function 'get_variable_transfer_data'",
+    )
     def variable_transfer_data(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'variable_transfer_data' is deprecated in favor of the function 'get_variable_transfer_data'",
-            DeprecationWarning,
-        )
         return self.get_variable_transfer_data()
 
     def get_variable_transfer_data(self):
@@ -504,12 +498,11 @@ class VariableContainer(Variable, Mapping):
         return data
 
     @property
+    @deprecated(
+        "the property 'named_variable_values' is deprecated in favor of the function 'get_named_variable_values'",
+    )
     def named_variable_values(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'named_variable_values' is deprecated in favor of the function 'get_named_variable_values'",
-            DeprecationWarning,
-        )
         return self.get_named_variable_values()
 
     def get_named_variable_values(self):
@@ -520,12 +513,11 @@ class VariableContainer(Variable, Mapping):
         }
 
     @property
+    @deprecated(
+        "the property 'positional_variable_values' is deprecated in favor of the function 'get_positional_variable_values'",
+    )
     def positional_variable_values(self):
         """DEPRECATED"""
-        warnings.warn(
-            "the property 'positional_variable_values' is deprecated in favor of the function 'get_positional_variable_values'",
-            DeprecationWarning,
-        )
         return self.get_positional_variable_values()
 
     def get_positional_variable_values(self):


### PR DESCRIPTION
***In GitLab by @loichuder on Mar 27, 2025, 09:55 GMT+1:***

When addressing https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/284#note_413544, I realized that there are other warnings that did not have the `stacklevel = 2`.

I wanted to add an utility to raise the warning consistently and a quick search shows that a decorator to do exactly this is in `warnings`: https://docs.python.org/3/library/warnings.html#warnings.deprecated

Unfortunately, this decorator is only added in Python 3.13 so I added an implementation for earlier version in `utils`. We could add it to `ewoksutil`?

**EDIT: Added in `ewoksutils` and this MR adds the import**

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/285*