### PR TITLE
improve TaskInputError to describe which task raises the error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+Changes:
+
+- improve `TaskInputError` to describe which task raises the error.
+
 ## 1.4.0
 
 New features:

--- a/src/ewokscore/methodtask.py
+++ b/src/ewokscore/methodtask.py
@@ -1,5 +1,8 @@
-from .task import Task
+from typing import Mapping
+
 from ewoksutils.import_utils import import_method
+
+from .task import Task
 
 METHOD_ARGUMENT = "_method"
 
@@ -8,6 +11,9 @@ class MethodExecutorTask(
     Task, input_names=[METHOD_ARGUMENT], output_names=["return_value"]
 ):
     METHOD_ARGUMENT = METHOD_ARGUMENT
+
+    def _get_task_identifier(self, inputs: Mapping) -> str:
+        return inputs.get(self.METHOD_ARGUMENT, self.class_registry_name())
 
     def run(self):
         kwargs = self.get_named_input_values()

--- a/src/ewokscore/ppftasks.py
+++ b/src/ewokscore/ppftasks.py
@@ -1,5 +1,8 @@
-from .task import Task
+from typing import Mapping
+
 from ewoksutils.import_utils import import_method
+
+from .task import Task
 
 METHOD_ARGUMENT = "_method"
 PPF_DICT_ARGUMENT = "_ppfdict"
@@ -18,6 +21,9 @@ class PpfMethodExecutorTask(
 
     METHOD_ARGUMENT = METHOD_ARGUMENT
     PPF_DICT_ARGUMENT = PPF_DICT_ARGUMENT
+
+    def _get_task_identifier(self, inputs: Mapping) -> str:
+        return inputs.get(self.METHOD_ARGUMENT, self.class_registry_name())
 
     def run(self):
         method_kwargs = self.get_input_values()
@@ -39,6 +45,9 @@ class PpfPortTask(
     """A ppfmethod which represents the identity mapping"""
 
     PPF_DICT_ARGUMENT = PPF_DICT_ARGUMENT
+
+    def _get_task_identifier(self, inputs: Mapping) -> str:
+        return ""
 
     def run(self):
         method_kwargs = self.get_input_values()

--- a/src/ewokscore/scripttask.py
+++ b/src/ewokscore/scripttask.py
@@ -2,6 +2,8 @@ import os
 import sys
 import logging
 import subprocess
+from typing import Mapping
+
 from .task import Task
 
 SCRIPT_ARGUMENT = "_script"
@@ -88,6 +90,9 @@ class ScriptExecutorTask(
     """
 
     SCRIPT_ARGUMENT = SCRIPT_ARGUMENT
+
+    def _get_task_identifier(self, inputs: Mapping) -> str:
+        return inputs.get(self.SCRIPT_ARGUMENT, self.class_registry_name())
 
     def run(self):
         fullname = self.inputs._script

--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -59,8 +59,6 @@ class Task(Registered, UniversalHashable, register=False):
         elif not isinstance(inputs, Mapping):
             raise TypeError(inputs, type(inputs))
 
-        inputs = self._check_inputs(inputs)
-
         # Required outputs for the task to be "done"
         ovars = {varname: self.MISSING_DATA for varname in self._OUTPUT_NAMES}
 
@@ -68,6 +66,7 @@ class Task(Registered, UniversalHashable, register=False):
         node_id = node.get_node_id(node_id, node_attrs)
         self.__node_id = node_id
         self.__node_label = node.get_node_label(node_id, node_attrs)
+        self.__task_identifier = self._get_task_identifier(inputs)
         task_id = self.class_registry_name()
         task_id = node.get_task_identifier(node_attrs, task_id)
         self.__task_id = task_id
@@ -85,6 +84,7 @@ class Task(Registered, UniversalHashable, register=False):
         # The output hash will update dynamically if any of the input
         # variables change
         varinfo = node.get_varinfo(node_attrs, varinfo)
+        inputs = self._check_inputs(inputs)
         self.__inputs = VariableContainer(value=inputs, varinfo=varinfo)
         self.__outputs = VariableContainer(
             value=ovars,
@@ -111,7 +111,7 @@ class Task(Registered, UniversalHashable, register=False):
             try:
                 validated_inputs = self._INPUT_MODEL(**inputs)
             except ValidationError as e:
-                raise TaskInputError(e) from e
+                self._raise_task_input_error("Invalid inputs", str(e))
             # Note: warnings are suppressed because `BaseInputModel` allows
             # special field types like `Variable` to pass through unvalidated.
             return validated_inputs.model_dump(warnings="none")
@@ -119,14 +119,14 @@ class Task(Registered, UniversalHashable, register=False):
         # Check required inputs
         missing_required = set(self._INPUT_NAMES) - set(inputs.keys())
         if missing_required:
-            raise TaskInputError(f"Missing inputs for {type(self)}: {missing_required}")
+            self._raise_task_input_error("Missing inputs", str(missing_required))
 
         # Check required positional inputs
         nrequiredargs = self._N_REQUIRED_POSITIONAL_INPUTS
         for i in range(nrequiredargs):
             if i not in inputs and str(i) not in inputs:
-                raise TaskInputError(
-                    f"Missing inputs for {type(self)}: positional argument #{i}"
+                self._raise_task_input_error(
+                    "Missing inputs", f"positional argument #{i}"
                 )
 
         # Init missing optional inputs
@@ -453,6 +453,13 @@ class Task(Registered, UniversalHashable, register=False):
         return self.__node_id
 
     @property
+    def task_identifier(self) -> str:
+        return self.__task_identifier
+
+    def _get_task_identifier(self, inputs: Mapping) -> str:
+        return self.class_registry_name()
+
+    @property
     def job_id(self) -> Optional[str]:
         if self.__execinfo:
             return self.__execinfo.get("job_id")
@@ -515,8 +522,20 @@ class Task(Registered, UniversalHashable, register=False):
     def assert_ready_to_execute(self):
         lst = list(self._iter_missing_input_values())
         if lst:
+            self._raise_task_input_error(
+                "The following inputs could not be loaded", str(lst)
+            )
+
+    def _raise_task_input_error(self, prefix: str, message: str) -> None:
+        node_id = self.__node_id
+        task_identifier = self.task_identifier
+        if self.__node_label:
             raise TaskInputError(
-                "The following inputs could not be loaded: " + str(lst)
+                f"{prefix} for ewoks task {self.__node_label!r} (id: {node_id!r}, task: {task_identifier!r}): {message}"
+            )
+        else:
+            raise TaskInputError(
+                f"{prefix} for ewoks task (id: {node_id!r}, task: {task_identifier!r}): {message}"
             )
 
     def reset_state(self):


### PR DESCRIPTION
***In GitLab by @woutdenolf on May 9, 2025, 14:40 GMT+2:***

Instead of

```python
ewokscore.task.TaskInputError: 1 validation error for Inputs
image_stacks
  Field required [type=missing, input_value={'output_root_uri': <ewok...028f2823c0>(uhash=None)}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

we now see

```python
ewokscore.task.TaskInputError: Invalid inputs for ewoks task '2D Transformation' (id: '3', task: 'ewoksndreg.tasks.reg2d_transform.Reg2DTransform'): 1 validation error for Inputs
image_stacks
  Field required [type=missing, input_value={'output_root_uri': <ewok...4e8f8bdeb0>(uhash=None)}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

The traceback itself does not contain any hints what task it is

```python
Traceback (most recent call last):
  File "/home/denolf/projects/ewoks/src/ewoks/__main__.py", line 61, in command_execute
    results = execute_graph(graph, engine=args.engine, **args.execute_options)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewoks/src/ewoks/bindings.py", line 81, in execute_graph
    result = mod.execute_graph(graph, execinfo=execinfo, **execute_options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/events/contexts.py", line 25, in wrapper
    return method(*args, execinfo=execinfo, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/bindings.py", line 56, in execute_graph
    return sequential.execute_graph(taskgraph.graph, **execute_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/graph/execute/sequential.py", line 122, in execute_graph
    task = instantiate_task_static(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/graph/execute/sequential.py", line 69, in instantiate_task_static
    target_task = instantiate_task(
                  ^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/graph/execute/sequential.py", line 20, in instantiate_task
    return _instantiate_task(node_id, nodeattrs, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/inittask.py", line 155, in instantiate_task
    return Task.instantiate(task_info["task_identifier"], **task_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/task.py", line 248, in instantiate
    return cls.get_subclass(registry_name)(**kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/task.py", line 62, in __init__
    inputs = self._check_inputs(inputs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/denolf/projects/ewokscore/src/ewokscore/task.py", line 114, in _check_inputs
    raise TaskInputError(e) from e
```

**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/297*