### PR TITLE
bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 1.5.0
+
 Changes:
 
 - Improve `TaskInputError` to describe which task raises the error.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ewokscore"
-version = "1.4.0"
+version = "1.5.0"
 authors = [{ name = "ESRF", email = "dau-pydev@esrf.fr" }]
 description = "API for graphs and tasks in Ewoks"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
***In GitLab by @woutdenolf on May 16, 2025, 14:42 GMT+2:***



**Assignees:** @woutdenolf

**Reviewers:** @loichuder

**Approved by:** @loichuder

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/299*