### PR TITLE
Fields of task input models are no longer serialized when executing the task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+- Fields of task input models are no longer serialized when executing the task. For example, a `dataclass` stays a `dataclass` instead of becoming a `dict`.
+
 ## 2.0.0
 
 New features:
@@ -54,7 +58,7 @@ Bug fixes:
 
 Deprecations:
 
-- `ewokscore.task.Task`: `npositional_inputs`  is deprecated in favor of `n_positional_inputs`
+- `ewokscore.task.Task`: `npositional_inputs` is deprecated in favor of `n_positional_inputs`
 
 ## 1.2.0
 

--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -139,12 +139,15 @@ class Task(Registered, UniversalHashable, register=False):
 
         :raises pydantic.ValidationError:
         """
+        if self._INPUT_MODEL is None:
+            raise ValueError(
+                "Trying to validate inputs while no input model was specified"
+            )
         inputs = self.__inputs.get_variable_values()
         model = self._INPUT_MODEL(**inputs)
 
-        validated_inputs = model.model_dump()
-        for name, value in validated_inputs.items():
-            self.__inputs[name].value = value
+        for name in self._INPUT_MODEL.model_fields.keys():
+            self.__inputs[name].value = getattr(model, name)
 
     def __init_subclass__(
         subclass,

--- a/src/ewokscore/tests/test_task_model.py
+++ b/src/ewokscore/tests/test_task_model.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Union
 
 import pytest
@@ -291,3 +292,23 @@ def test_wrapped_type_coercion(tmp_path):
         input_variable = task.input_variables["age"]
         assert input_variable.uhash == fixed_uhash
         assert variable.uhash == fixed_uhash
+
+
+def test_dataclass_field_stays_dataclass():
+    @dataclass
+    class Address:
+        city: str
+        street: str
+
+    class Inputs(BaseInputModel):
+        address: Address
+
+    class CheckAddress(Task, input_model=Inputs):
+        def run(self):
+            address = self.inputs.address
+            assert isinstance(address, Address)
+
+    task = CheckAddress(
+        inputs={"address": Address(city="Grenoble", street="Jean-Jaurès")}
+    )
+    task.execute()


### PR DESCRIPTION
***In GitLab by @loichuder on Jul 16, 2025, 18:15 GMT+2:***

Reported by @maxenceprog 

Closes https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/issues/73

It was actually an error to use `model_dump()` to get dynamically the model field names and values. `model_dump` serializes the inputs so that some objects get transformed.

For example, in darfix, we use a `Dataset` `dataclass` and it got converted to `dict` when executing the task when we moved to input models.

In this PR, I remove the use of `model_dump` in favour of a simple loop on field names and use `__getattribute__` to get the values.

**Assignees:** @loichuder

**Reviewers:** @woutdenolf

**Approved by:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/305*