### PR TITLE
bump version to 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] - 2025-10-31
+
 ### Added
 
 - Support `test_core` graph representation.
@@ -338,7 +340,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `execute_graph` for naive task scheduling in a single thread.
 - Execution events based on python's logging facility.
 
-[unreleased]: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/compare/v2.0.1...HEAD
+[unreleased]: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/compare/v3.0.0...HEAD
+[3.0.0]: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/compare/v2.0.1...v3.0.0
 [2.0.1]: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/compare/v2.0.0...v2.0.1
 [2.0.0]: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/compare/v1.6.0...v2.0.0
 [1.6.0]: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/compare/v1.5.0...v1.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ewokscore"
-version = "2.0.1"
+version = "3.0.0"
 authors = [{ name = "ESRF", email = "dau-pydev@esrf.fr" }]
 description = "API for graphs and tasks in Ewoks"
 readme = { file = "README.md", content-type = "text/markdown" }


### PR DESCRIPTION
***In GitLab by @woutdenolf on Oct 31, 2025, 10:44 GMT+1:***



**Assignees:** @woutdenolf

*Migrated from GitLab: https://gitlab.esrf.fr/workflow/ewoks/ewokscore/-/merge_requests/323*