### PR TITLE
Fix TaskGraph.dump return value typing

### DIFF
--- a/src/ewokscore/graph/taskgraph.py
+++ b/src/ewokscore/graph/taskgraph.py
@@ -132,7 +132,7 @@ class TaskGraph:
         destination: Optional[Union[str, Path]] = None,
         representation: Optional[Union[serialize.GraphRepresentation, str]] = None,
         **save_options,
-    ) -> Optional[Union[str, Path, dict]]:
+    ) -> Union[str, Path, dict]:
         return serialize.dump(
             self.graph,
             destination=destination,


### PR DESCRIPTION
According to `serialize.dump` typing, `TaskGraph.dump` cannot return `None`.

https://github.com/ewoks-kit/ewokscore/blob/e818420cf972464343fd744e126fa358167a959b/src/ewokscore/graph/serialize.py#L36