### PR TITLE
graph serialization: make special keys more specific

### DIFF
--- a/src/ewokscore/_serialization/common.py
+++ b/src/ewokscore/_serialization/common.py
@@ -9,7 +9,6 @@ import base64
 import pickle
 from typing import Any
 from typing import Callable
-from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -28,10 +27,19 @@ class EwoksDecodeError(ValueError):
     pass
 
 
+_PathPattern = Tuple[Union[str, int], ...]
+RuleType = Tuple[_PathPattern, Callable[[Any], Any]]
+
+
 def pre_serialize(
-    obj: Any, special_keys: Optional[Dict[str, Callable[[Any], Any]]] = None
+    obj: Any,
+    custom_rules: Optional[List[RuleType]] = None,
 ) -> Any:
-    special_keys = special_keys or {}
+    """
+    :param obj: object to serialize
+    :param custom_rules: dictionary keys with associated custom value serialization
+    """
+    custom_rules = custom_rules or []
     t = _Traversal(obj)
 
     while t.next():
@@ -67,8 +75,9 @@ def pre_serialize(
             t.assign(new_dict)
 
             for k, v in reversed(list(current.items())):
-                if k in special_keys:
-                    new_dict[k] = special_keys[k](v)
+                matched, new_val = _apply_special_rules(t.path, k, v, custom_rules)
+                if matched:
+                    new_dict[k] = new_val
                 else:
                     t.append_dict_key(new_dict, k, v)
             continue
@@ -123,9 +132,14 @@ def pre_serialize(
 
 
 def post_deserialize(
-    obj: Any, special_keys: Optional[Dict[str, Callable[[Any], Any]]] = None
+    obj: Any,
+    custom_rules: Optional[List[RuleType]] = None,
 ) -> Any:
-    special_keys = special_keys or {}
+    """
+    :param obj: object to serialize
+    :param custom_rules: dictionary keys with associated custom value deserialization
+    """
+    custom_rules = custom_rules or []
     t = _Traversal(obj)
 
     while t.next():
@@ -138,8 +152,9 @@ def post_deserialize(
                 t.assign(new_dict)
 
                 for k, v in reversed(list(current.items())):
-                    if k in special_keys:
-                        new_dict[k] = special_keys[k](v)
+                    matched, new_val = _apply_special_rules(t.path, k, v, custom_rules)
+                    if matched:
+                        new_dict[k] = new_val
                     else:
                         t.append_dict_key(new_dict, k, v)
                 continue
@@ -198,6 +213,7 @@ _EWOKS_KEY = "__ewoks__"
 
 _ParentType = Union[None, list, dict]
 _KeyType = Union[None, int, str]
+_Path = Tuple[Union[str, int], ...]
 
 
 class _MutableContainer:
@@ -211,11 +227,14 @@ class _MutableContainer:
 
 class _Traversal:
     def __init__(self, root: Any):
-        self._stack: List[Tuple[_ParentType, _KeyType, Any]] = [(None, None, root)]
+        self._stack: List[Tuple[_ParentType, _KeyType, Any, _Path]] = [
+            (None, None, root, ())
+        ]
         self._result = None
         self._parent: _ParentType = None
         self._key: _KeyType = None
         self._current = None
+        self._path: _Path = ()
 
     @property
     def result(self) -> Any:
@@ -233,10 +252,14 @@ class _Traversal:
     def current(self) -> Any:
         return self._current
 
+    @property
+    def path(self) -> _Path:
+        return self._path
+
     def next(self) -> bool:
         if not self._stack:
             return False
-        self._parent, self._key, self._current = self._stack.pop()
+        self._parent, self._key, self._current, self._path = self._stack.pop()
         return True
 
     def assign(self, value: Any) -> None:
@@ -246,11 +269,11 @@ class _Traversal:
             self._parent[self._key] = value
 
     def append_dict_key(self, parent: _ParentType, key: _KeyType, value: Any) -> None:
-        self._stack.append((parent, key, value))
+        self._stack.append((parent, key, value, self._path + (key,)))
 
     def append_sequence_items(self, parent: Any, items: Sequence) -> None:
         for key in reversed(range(len(items))):
-            self._stack.append((parent, key, items[key]))
+            self._stack.append((parent, key, items[key], self._path + (key,)))
 
 
 def _convert_if_equal(value: Any, new_type: Type) -> Optional[Any]:
@@ -260,3 +283,27 @@ def _convert_if_equal(value: Any, new_type: Type) -> Optional[Any]:
             return new_value
     except Exception:
         pass
+
+
+def _match_path(path: _Path, pattern: _PathPattern) -> bool:
+    if len(path) != len(pattern):
+        return False
+    for p, pat in zip(path, pattern):
+        if pat == "*":
+            continue
+        if p != pat:
+            return False
+    return True
+
+
+def _apply_special_rules(
+    path: _Path,
+    key: Union[str, int],
+    value: Any,
+    rules: List[RuleType],
+) -> Tuple[bool, Any]:
+    full_path = path + (key,)
+    for pattern, func in rules:
+        if _match_path(full_path, pattern):
+            return True, func(value)
+    return False, None

--- a/src/ewokscore/_serialization/json.py
+++ b/src/ewokscore/_serialization/json.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any
-from typing import Callable
-from typing import Dict
+from typing import List
 from typing import Optional
 from typing import TextIO
 
@@ -9,30 +8,30 @@ from . import common
 
 
 def dumps(
-    obj: Any, special_keys: Optional[Dict[str, Callable[[Any], str]]] = None, **kwargs
+    obj: Any, custom_rules: Optional[List[common.RuleType]] = None, **kwargs
 ) -> str:
     """
     Serialize Python object to JSON string.
     """
-    pre = common.pre_serialize(obj, special_keys=special_keys)
+    pre = common.pre_serialize(obj, custom_rules=custom_rules)
     return json.dumps(pre, **kwargs)
 
 
 def dump(
     obj: Any,
     fp: TextIO,
-    special_keys: Optional[Dict[str, Callable[[Any], str]]] = None,
+    custom_rules: Optional[List[common.RuleType]] = None,
     **kwargs,
 ) -> None:
     """
     Write Python object to JSON file-like object.
     """
-    pre = common.pre_serialize(obj, special_keys=special_keys)
+    pre = common.pre_serialize(obj, custom_rules=custom_rules)
     json.dump(pre, fp, **kwargs)
 
 
 def loads(
-    s: str, special_keys: Optional[Dict[str, Callable[[Any], str]]] = None, **kwargs
+    s: str, custom_rules: Optional[List[common.RuleType]] = None, **kwargs
 ) -> Any:
     """
     Deserialize JSON string to Python object.
@@ -42,11 +41,11 @@ def loads(
     except (json.JSONDecodeError, TypeError) as e:
         raise common.EwoksDecodeError from e
 
-    return common.post_deserialize(raw, special_keys=special_keys)
+    return common.post_deserialize(raw, custom_rules=custom_rules)
 
 
 def load(
-    fp: TextIO, special_keys: Optional[Dict[str, Callable[[Any], str]]] = None, **kwargs
+    fp: TextIO, custom_rules: Optional[List[common.RuleType]] = None, **kwargs
 ) -> Any:
     """
     Load Python object from JSON file-like object.
@@ -56,4 +55,4 @@ def load(
     except (json.JSONDecodeError, TypeError) as e:
         raise common.EwoksDecodeError from e
 
-    return common.post_deserialize(raw, special_keys=special_keys)
+    return common.post_deserialize(raw, custom_rules=custom_rules)

--- a/src/ewokscore/_serialization/yaml.py
+++ b/src/ewokscore/_serialization/yaml.py
@@ -1,6 +1,5 @@
 from typing import Any
-from typing import Callable
-from typing import Dict
+from typing import List
 from typing import Optional
 from typing import TextIO
 
@@ -10,30 +9,30 @@ from . import common
 
 
 def dumps(
-    obj: Any, special_keys: Optional[Dict[str, Callable[[Any], str]]] = None, **kwargs
+    obj: Any, custom_rules: Optional[List[common.RuleType]] = None, **kwargs
 ) -> str:
     """
     Serialize Python object to YAML string.
     """
-    pre = common.pre_serialize(obj, special_keys=special_keys)
+    pre = common.pre_serialize(obj, custom_rules=custom_rules)
     return yaml.dump(pre, stream=None, Dumper=yaml.Dumper, **kwargs)
 
 
 def dump(
     obj: Any,
     fp: TextIO,
-    special_keys: Optional[Dict[str, Callable[[Any], str]]] = None,
+    custom_rules: Optional[List[common.RuleType]] = None,
     **kwargs,
 ) -> None:
     """
     Write Python object to YAML file-like object.
     """
-    pre = common.pre_serialize(obj, special_keys=special_keys)
+    pre = common.pre_serialize(obj, custom_rules=custom_rules)
     yaml.dump(pre, stream=fp, Dumper=yaml.Dumper, **kwargs)
 
 
 def loads(
-    s: str, special_keys: Optional[Dict[str, Callable[[Any], str]]] = None, **kwargs
+    s: str, custom_rules: Optional[List[common.RuleType]] = None, **kwargs
 ) -> Any:
     """
     Deserialize YAML string to Python object.
@@ -43,11 +42,11 @@ def loads(
     except (yaml.YAMLError, TypeError) as e:
         raise common.EwoksDecodeError from e
 
-    return common.post_deserialize(raw, special_keys=special_keys)
+    return common.post_deserialize(raw, custom_rules=custom_rules)
 
 
 def load(
-    fp: TextIO, special_keys: Optional[Dict[str, Callable[[Any], str]]] = None, **kwargs
+    fp: TextIO, custom_rules: Optional[List[common.RuleType]] = None, **kwargs
 ) -> Any:
     """
     Load Python object from YAML file-like object.
@@ -57,4 +56,4 @@ def load(
     except (yaml.YAMLError, TypeError) as e:
         raise common.EwoksDecodeError from e
 
-    return common.post_deserialize(raw, special_keys=special_keys)
+    return common.post_deserialize(raw, custom_rules=custom_rules)

--- a/src/ewokscore/graph/serialize.py
+++ b/src/ewokscore/graph/serialize.py
@@ -5,8 +5,7 @@ import os
 from collections.abc import Mapping
 from functools import lru_cache
 from pathlib import Path
-from typing import Callable
-from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Tuple
 from typing import Union
@@ -64,14 +63,14 @@ def dump(
                 dictrepr,
                 f,
                 **save_options,
-                special_keys=_get_special_graph_key_serializers(),
+                custom_rules=_get_custom_serialization_rules(),
             )
         return destination
 
     if representation == GraphRepresentation.json_string:
         dictrepr = dump(graph)
         return json.dumps(
-            dictrepr, **save_options, special_keys=_get_special_graph_key_serializers()
+            dictrepr, **save_options, custom_rules=_get_custom_serialization_rules()
         )
 
     if representation == GraphRepresentation.yaml:
@@ -84,7 +83,7 @@ def dump(
                 dictrepr,
                 f,
                 **save_options,
-                special_keys=_get_special_graph_key_serializers(),
+                custom_rules=_get_custom_serialization_rules(),
             )
         return destination
 
@@ -140,7 +139,7 @@ def load(
         graph = source.graph
     elif representation == GraphRepresentation.json_dict:
         graph_dict = common.post_deserialize(
-            source, special_keys=_get_special_graph_key_deserializers()
+            source, custom_rules=_get_custom_deserialization_rules()
         )
         graph = _dict_to_networkx(graph_dict)
     elif representation == GraphRepresentation.json:
@@ -232,11 +231,9 @@ def _read_any_file(
 
 def _json_load(content) -> dict:
     if isinstance(content, str):
-        result = json.loads(
-            content, special_keys=_get_special_graph_key_deserializers()
-        )
+        result = json.loads(content, custom_rules=_get_custom_deserialization_rules())
     else:
-        result = json.load(content, special_keys=_get_special_graph_key_deserializers())
+        result = json.load(content, custom_rules=_get_custom_deserialization_rules())
     if not isinstance(result, Mapping):
         raise TypeError("graph must be a dictionary")
     return result
@@ -244,11 +241,9 @@ def _json_load(content) -> dict:
 
 def _yaml_load(content) -> dict:
     if isinstance(content, str):
-        result = yaml.loads(
-            content, special_keys=_get_special_graph_key_deserializers()
-        )
+        result = yaml.loads(content, custom_rules=_get_custom_deserialization_rules())
     else:
-        result = yaml.load(content, special_keys=_get_special_graph_key_deserializers())
+        result = yaml.load(content, custom_rules=_get_custom_deserialization_rules())
     if not isinstance(result, Mapping):
         raise TypeError("graph must be a dictionary")
     return result
@@ -330,26 +325,35 @@ def _networkx_to_dict(graph: networkx.DiGraph) -> dict:
     return graph_dict
 
 
-_NODE_ID_KEYS = (
-    "source",
-    "target",
-    "sub_source",
-    "sub_target",
-    "id",
-    "node",
-    "sub_node",
-)
+@lru_cache
+def _get_custom_serialization_rules() -> List[common.RuleType]:
+    return [
+        (("nodes", "*", "id"), node.as_json_node_id_type),
+        (("nodes", "*", "node"), node.as_json_node_id_type),
+        (("nodes", "*", "sub_node"), node.as_json_node_id_type),
+        (("links", "*", "source"), node.as_json_node_id_type),
+        (("links", "*", "target"), node.as_json_node_id_type),
+        (("links", "*", "sub_source"), node.as_json_node_id_type),
+        (("links", "*", "sub_target"), node.as_json_node_id_type),
+        (("subgraphs", "*", "id"), node.as_json_node_id_type),
+        (("subgraphs", "*", "nodes", "*", "id"), node.as_json_node_id_type),
+        (("subgraphs", "*", "links", "*", "source"), node.as_json_node_id_type),
+        (("subgraphs", "*", "links", "*", "target"), node.as_json_node_id_type),
+    ]
 
 
 @lru_cache
-def _get_special_graph_key_serializers() -> Dict[
-    str, Callable[[node.NodeIdType], node.JsonNodeIdType]
-]:
-    return {k: node.as_json_node_id_type for k in _NODE_ID_KEYS}
-
-
-@lru_cache
-def _get_special_graph_key_deserializers() -> Dict[
-    str, Callable[[node.JsonNodeIdType], node.NodeIdType]
-]:
-    return {k: node.as_node_id_type for k in _NODE_ID_KEYS}
+def _get_custom_deserialization_rules() -> List[common.RuleType]:
+    return [
+        (("nodes", "*", "id"), node.as_node_id_type),
+        (("nodes", "*", "node"), node.as_node_id_type),
+        (("nodes", "*", "sub_node"), node.as_node_id_type),
+        (("links", "*", "source"), node.as_node_id_type),
+        (("links", "*", "target"), node.as_node_id_type),
+        (("links", "*", "sub_source"), node.as_node_id_type),
+        (("links", "*", "sub_target"), node.as_node_id_type),
+        (("subgraphs", "*", "id"), node.as_node_id_type),
+        (("subgraphs", "*", "nodes", "*", "id"), node.as_node_id_type),
+        (("subgraphs", "*", "links", "*", "source"), node.as_node_id_type),
+        (("subgraphs", "*", "links", "*", "target"), node.as_node_id_type),
+    ]

--- a/src/ewokscore/tests/serialization/test_common.py
+++ b/src/ewokscore/tests/serialization/test_common.py
@@ -1,4 +1,6 @@
-import numpy as numpy
+from copy import deepcopy
+
+import numpy
 import pytest
 
 from ..._serialization import common
@@ -65,7 +67,7 @@ def test_dict():
 
 def test_nested():
     obj = {"a": [1, {"b": (2, 3)}]}
-    assert _roundtrip(obj) == {"a": [1, {"b": (2, 3)}]}
+    assert _roundtrip(obj) == obj
 
 
 def test_tuple():
@@ -104,24 +106,29 @@ def test_pickle_fallback():
     assert result == obj
 
 
-def test_special_keys_encode():
-    obj = {"x": 1}
+def test_special_rules():
+    obj = {"links": [{"source": 1}, {"other": 2}]}
 
     def encode(v):
         return f"encoded:{v}"
 
-    result = common.pre_serialize(obj, special_keys={"x": encode})
-    assert result["x"] == "encoded:1"
-
-
-def test_special_keys_decode():
-    obj = {"x": "encoded:1"}
-
     def decode(v):
         return int(v.split(":")[1])
 
-    result = common.post_deserialize(obj, special_keys={"x": decode})
-    assert result["x"] == 1
+    encode_rules = [
+        (("links", "*", "source"), encode),
+    ]
+
+    decode_rules = [
+        (("links", "*", "source"), decode),
+    ]
+
+    result = common.pre_serialize(obj, custom_rules=encode_rules)
+    assert result["links"][0] == {"source": "encoded:1"}
+    assert result["links"][1] == {"other": 2}
+
+    obj2 = common.post_deserialize(result, custom_rules=decode_rules)
+    assert obj == obj2
 
 
 def test_reserved_key_error():
@@ -136,7 +143,7 @@ def test_unknown_tag():
         common.post_deserialize(obj)
 
 
-def test_deep_nesting():
+def test_no_max_recursion_exeception():
     depth = 10000
     obj = current = {}
     for _ in range(depth):
@@ -144,7 +151,7 @@ def test_deep_nesting():
         current["x"] = new
         current = new
 
-    result = _roundtrip(obj)
+    result = _unsaferoundtrip(obj)
     assert isinstance(result, dict)
 
 
@@ -155,14 +162,12 @@ def test_complex_structure():
         "c": b"bytes",
         "d": {"nested": numpy.int64(7)},
     }
-
-    result = _roundtrip(obj)
-
-    assert result["a"][2] == (3, 4)
-    assert result["b"] == {5, 6}
-    assert result["c"] == b"bytes"
-    assert result["d"]["nested"] == 7
+    assert _roundtrip(obj) == obj
 
 
 def _roundtrip(obj):
+    return common.post_deserialize(common.pre_serialize(deepcopy(obj)))
+
+
+def _unsaferoundtrip(obj):
     return common.post_deserialize(common.pre_serialize(obj))


### PR DESCRIPTION
Graph serialization has a special convention for some values that are of type `NodeIdType`. This was already the case before the refactoring of the serialization and we kept it during the refactoring. FYI the refactoring was associated to the support of pickling.

However [the original implementation](https://github.com/ewoks-kit/ewokscore/blob/e71bd42100969c743296a98bcadc0b876100a900/src/ewokscore/graph/serialize.py#L232) just looks at the name of the key (for example `"id"`) to decide whether the value is a `NodeIdType`. After the refactoring this is still the case.

So you could have corner cases where a `default_inputs` item would be for example `{"id": ...}` and this would be interpreted as a `NodeIdType` but shouldn't.

In this PR we take the full path into account for custom (de)serializated keys. For example instead of `key == "id"` we call `_match_path` with the following path patterns

- `("nodes", "*", "id")`
- `("subgraphs", "*", "id")`
- `("subgraphs", "*", "nodes", "*", "id")`

More verbose but more precise than just `"id"`.