### PR TITLE
python full qualifier name as id for package-data graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Error was logged at INFO level in app logs and ewoks events. Now error is logged at the error level.
 
+### Changed
+
+- Graphs which are python package-data files are ensured to have the python full qualifier name as graph id.
+
 ## [5.0.0rc1] - 2026-04-13
 
 ### Added

--- a/src/ewokscore/graph/serialize.py
+++ b/src/ewokscore/graph/serialize.py
@@ -179,27 +179,27 @@ def _read_json_file(
     root_dir: Optional[Union[str, Path]] = None,
     root_module: Optional[str] = None,
 ) -> dict:
-    filename = _find_graph_path(
+    filename, graph_id = _find_graph_path(
         filename,
         root_dir=root_dir,
         root_module=root_module,
         possible_extensions=(".json",),
     )
     with open(filename, mode="r") as f:
-        return _json_load(f)
+        return _overwrite_graph_id(_json_load(f), graph_id)
 
 
 def _read_yaml_file(
     filename: str, root_dir: Optional[str] = None, root_module: Optional[str] = None
 ) -> dict:
-    filename = _find_graph_path(
+    filename, graph_id = _find_graph_path(
         filename,
         root_dir=root_dir,
         root_module=root_module,
         possible_extensions=(".yml", ".yaml"),
     )
     with open(filename, mode="r") as f:
-        return _yaml_load(f)
+        return _overwrite_graph_id(_yaml_load(f), graph_id)
 
 
 def _read_any_file(
@@ -207,7 +207,7 @@ def _read_any_file(
     root_dir: Optional[Union[str, Path]] = None,
     root_module: Optional[str] = None,
 ) -> Optional[dict]:
-    filename = _find_graph_path(
+    filename, graph_id = _find_graph_path(
         filename,
         root_dir=root_dir,
         root_module=root_module,
@@ -217,12 +217,12 @@ def _read_any_file(
         content = f.read()
 
     try:
-        return _json_load(content)
+        return _overwrite_graph_id(_json_load(content), graph_id)
     except common.EwoksDecodeError:
         pass
 
     try:
-        return _yaml_load(content)
+        return _overwrite_graph_id(_yaml_load(content), graph_id)
     except common.EwoksDecodeError:
         pass
 
@@ -254,7 +254,7 @@ def _find_graph_path(
     root_dir: Optional[Union[str, Path]] = None,
     root_module: Optional[str] = None,
     possible_extensions: Tuple[str, ...] = tuple(),
-) -> str:
+) -> Tuple[str, Optional[str]]:
     """When the :code:`path` is relative, the parent directory is assumed to be
     (in order of priority):
 
@@ -269,26 +269,49 @@ def _find_graph_path(
     :param root_dir: in case :code:`path` is relative
     :param root_module: in case :code:`root_module` is not provided
     :param possible_extensions: in case :code:`path` is not found
+    :returns: file path and graph identifier
     :raises: FileNotFoundError
     """
-    # Absolute path
+    # From python module
     if not root_dir and root_module:
         root_dir = _package_path(root_module)
+    else:
+        root_module = None
+
+    # Absolute path
     if not os.path.isabs(path) and root_dir:
         path = os.path.join(root_dir, path)
     path = os.path.abspath(path)
 
     if os.path.exists(path):
-        return path
+        graph_id = _graph_id_from_package_data_path(root_module, path)
+        return path, graph_id
 
     # Try different extensions
     root, _ = os.path.splitext(path)
     for new_ext in possible_extensions:
         new_full_path = root + new_ext
         if os.path.exists(new_full_path):
-            return new_full_path
+            graph_id = _graph_id_from_package_data_path(root_module, new_full_path)
+            return new_full_path, graph_id
 
     raise FileNotFoundError(path)
+
+
+def _graph_id_from_package_data_path(
+    root_module: Optional[str], path: str
+) -> Optional[str]:
+    if root_module is None:
+        return None
+    stem = os.path.splitext(os.path.basename(path))[0]
+    return f"{root_module}.{stem}"
+
+
+def _overwrite_graph_id(graph_dict: dict, graph_id: Optional[str]) -> dict:
+    if graph_id is None:
+        return graph_dict
+    graph_dict.setdefault("graph", {})["id"] = graph_id
+    return graph_dict
 
 
 def _package_path(package: str) -> str:

--- a/src/ewokscore/graph/serialize.py
+++ b/src/ewokscore/graph/serialize.py
@@ -267,7 +267,7 @@ def _find_graph_path(
 
     :param path: could be a relative path, might have no extension
     :param root_dir: in case :code:`path` is relative
-    :param root_module: in case :code:`root_module` is not provided
+    :param root_module: in case :code:`root_dir` is not provided
     :param possible_extensions: in case :code:`path` is not found
     :returns: file path and graph identifier
     :raises: FileNotFoundError

--- a/src/ewokscore/tests/serialization/test_graph.py
+++ b/src/ewokscore/tests/serialization/test_graph.py
@@ -53,6 +53,7 @@ def test_graph_discovery_json_module(with_representation):
     )
 
     assert set(ewoksgraph.graph.nodes) == {"node1", ("node2", "subnode1")}
+    assert ewoksgraph.graph.graph["id"] == "ewokscore.tests.examples.loadtest.graph"
 
 
 def _dump_graph_and_subgraph(tmp_path, format, with_ext):


### PR DESCRIPTION
Closes #435 

This is the first step in supporting non-editable workflows in `ewoksserver`.

Ewoksserver stores workflows in JSON files (editable workflows) and the graph id is equal to the stem for the filename. When the user creates a graph with the name "mygraph" then a file called "mygraph.json" is saved in the backend and the graph id is "graph". This allows ewoksserver to find the graph based on the id.

Non-editable workflows are files in python packages. This PR: to ensure uniqueness the python full qualifier name is forced to be the graph id, overwriting whatever the graph id is in the json file. It also allows ewoksserver to find the graph based on the id.