### PR TITLE
add workflow discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Support for Graph serialization and transparent handling of `Numpy arrays` in both JSON and 
-YAML via pickling.
+  YAML via pickling.
+- Add workflow discovery from python package data files in analogy to task discovery.
+  Full qualifier names or patterns can be added to the entry point group `"ewoks.workflows"`
+  of any python project.
 
 ## [5.0.0rc1] - 2026-04-13
 

--- a/doc/howtoguides.rst
+++ b/doc/howtoguides.rst
@@ -7,5 +7,6 @@ How-to Guides
     howtoguides/execute_io
     howtoguides/events
     howtoguides/task_discovery
+    howtoguides/workflow_discovery
     howtoguides/notebook_task
     howtoguides/change_schema

--- a/doc/howtoguides/task_discovery.rst
+++ b/doc/howtoguides/task_discovery.rst
@@ -26,18 +26,19 @@ To discover all tasks provided by all installed python packages
 For this to work the package that provides ewoks tasks should declare its task modules
 via the entry point mechanism.
 
-.. code-block:: ini
+.. code-block:: toml
 
-    # setup.cfg
+    # pyproject.toml
 
-    [options.entry_points]
-    ewoks.tasks.class =
-        myproject.module1.submoduleA=myproject1
-        myproject.*.tasks=myproject2
-    ewoks.tasks.method =
-        myproject.module3.submodule=myproject3
-    ewoks.tasks.ppfmethod =
-        myproject.actors.*=myproject4
+    [project.entry-points."ewoks.tasks.class"]
+    "myproject.module1.submoduleA" = "myproject1"
+    "myproject.*.tasks" = "myproject2"
+
+    [project.entry-points."ewoks.tasks.method"]
+    "myproject.module3.submodule" = "myproject3"
+
+    [project.entry-points."ewoks.tasks.ppfmethod"]
+    "myproject.actors.*" = "myproject4"
 
 The group names can be `"ewoks.tasks.class"`, `"ewoks.tasks.method"` or `"ewoks.tasks.ppfmethod"`.
 The key are the modules in which to discover tasks. The values are ignored but need to be globally
@@ -46,12 +47,10 @@ unique because of the way entry points work. Module names can contain wildcards 
 A project that provides ewoks tasks can also add the `"ewoks"` keyword to be discoverable in
 a package repository like PyPi:
 
-.. code-block:: ini
+.. code-block:: toml
 
-    # setup.cfg
+    # pyproject.toml
 
-    [metadata]
-    name = myproject
-    ...
-    keywords =
-        ewoks
+    [project]
+    name = "myproject"
+    keywords = ["ewoks"]

--- a/doc/howtoguides/task_discovery.rst
+++ b/doc/howtoguides/task_discovery.rst
@@ -1,13 +1,20 @@
 Task discovery
 ==============
 
+How to discover tasks
+---------------------
+
 All ewoks tasks provided by one or more python modules can be discovered as follows
 
 .. code-block:: python
 
     from ewokscore.task_discovery import discover_tasks_from_modules
 
-    tasks = discover_tasks_from_modules("myproject.module1", "myproject.module2", task_type="class")
+    tasks = discover_tasks_from_modules(
+        "myproject.module1",
+        "myproject.module2",
+        task_type="class",
+    )
 
 The `task_type` can have one of these values
 
@@ -23,8 +30,33 @@ To discover all tasks provided by all installed python packages
 
     tasks = discover_all_tasks(task_type="class")
 
-For this to work the package that provides ewoks tasks should declare its task modules
-via the entry point mechanism.
+The task discovery mechanism searches for tasks inside python packages and
+modules.
+
+For example
+
+.. code-block:: python
+
+    tasks = discover_tasks_from_modules(
+        "myproject.tasks.*"
+    )
+
+could discover task classes such as
+
+.. code-block:: text
+
+    myproject/tasks/demo.py      # MyDemoTask1, MyDemoTask2
+    myproject/tasks/example.py   # MyTask1, MyTask2
+
+The wildcard `"*"` matches exactly one package or module name component.
+
+
+How to declare tasks to be discovered
+-------------------------------------
+
+For automatic discovery to work across installed packages, a package that
+provides ewoks tasks should declare its task modules via the entry point
+mechanism.
 
 .. code-block:: toml
 
@@ -40,12 +72,18 @@ via the entry point mechanism.
     [project.entry-points."ewoks.tasks.ppfmethod"]
     "myproject.actors.*" = "myproject4"
 
-The group names can be `"ewoks.tasks.class"`, `"ewoks.tasks.method"` or `"ewoks.tasks.ppfmethod"`.
+The group names can be
 
-The keys are the module patterns in which to discover tasks. The values are ignored but typically the project
-name is used so the entry point can be loaded like any python entry point even though it is not used this way.
+* `"ewoks.tasks.class"`
+* `"ewoks.tasks.method"`
+* `"ewoks.tasks.ppfmethod"`
 
-The task discovery mechanism searches for tasks inside python packages and modules.
+The keys are the module patterns in which to discover tasks.
+
+The values are ignored but typically the project name is used so the entry
+point can be loaded like any python entry point even though it is not used
+this way.
+
 For example, the entry point
 
 .. code-block:: toml
@@ -53,15 +91,15 @@ For example, the entry point
     [project.entry-points."ewoks.tasks.class"]
     "myproject.tasks.*" = "myproject1"
 
-can discover task classes such as
+can declare task classes such as
 
 .. code-block:: text
 
-    myproject/tasks/demo.py  # MyDemoTask1, MyDemoTask2
-    myproject/tasks/example.py  # MyTask1, MyTask2
+    myproject/tasks/demo.py      # MyDemoTask1, MyDemoTask2
+    myproject/tasks/example.py   # MyTask1, MyTask2
 
-A project that provides ewoks tasks can also add the `"ewoks"` keyword to be discoverable in
-a package repository like PyPi:
+A project that provides ewoks tasks can also add the `"ewoks"` keyword to be
+discoverable in a package repository like PyPI:
 
 .. code-block:: toml
 

--- a/doc/howtoguides/task_discovery.rst
+++ b/doc/howtoguides/task_discovery.rst
@@ -41,8 +41,24 @@ via the entry point mechanism.
     "myproject.actors.*" = "myproject4"
 
 The group names can be `"ewoks.tasks.class"`, `"ewoks.tasks.method"` or `"ewoks.tasks.ppfmethod"`.
-The key are the modules in which to discover tasks. The values are ignored but need to be globally
-unique because of the way entry points work. Module names can contain wildcards `"*"`.
+
+The keys are the module patterns in which to discover tasks. The values are ignored but typically the project
+name is used so the entry point can be loaded like any python entry point even though it is not used this way.
+
+The task discovery mechanism searches for tasks inside python packages and modules.
+For example, the entry point
+
+.. code-block:: toml
+
+    [project.entry-points."ewoks.tasks.class"]
+    "myproject.tasks.*" = "myproject1"
+
+can discover task classes such as
+
+.. code-block:: text
+
+    myproject/tasks/demo.py  # MyDemoTask1, MyDemoTask2
+    myproject/tasks/example.py  # MyTask1, MyTask2
 
 A project that provides ewoks tasks can also add the `"ewoks"` keyword to be discoverable in
 a package repository like PyPi:

--- a/doc/howtoguides/workflow_discovery.rst
+++ b/doc/howtoguides/workflow_discovery.rst
@@ -66,8 +66,8 @@ via the entry point mechanism.
 
 The group name must be `"ewoks.workflows"`.
 
-The keys are the module patterns in which to discover workflows. The values are ignored but need
-to be globally unique because of the way entry points work.
+The keys are the module patterns in which to discover workflows. The values are ignored but typically the project
+name is used so the entry point can be loaded like any python entry point even though it is not used this way.
 
 The workflow discovery mechanism searches for workflow resource files inside python packages.
 For example, the entry point

--- a/doc/howtoguides/workflow_discovery.rst
+++ b/doc/howtoguides/workflow_discovery.rst
@@ -1,0 +1,96 @@
+Workflow discovery
+==================
+
+All ewoks workflows provided by one or more python modules can be discovered as follows
+
+.. code-block:: python
+
+    from ewokscore.workflow_discovery import discover_workflows_from_modules
+
+    workflows = discover_workflows_from_modules(
+        "myproject.workflows.*",
+        "myproject.subpackage.demo.*",
+        workflow_extension="json",
+    )
+
+The `workflow_extension` can have one of these values
+
+* `"json"`: discover JSON workflow resources
+* `"yaml"`: discover YAML workflow resources
+* `None` (default): discover both JSON and YAML workflow resources
+
+Module names can contain wildcards `"*"`.
+
+For example
+
+.. code-block:: python
+
+    workflows = discover_workflows_from_modules(
+        "myproject.*.workflows.*"
+    )
+
+could discover workflows such as
+
+.. code-block:: text
+
+    myproject.module1.workflows.graph1
+    myproject.module2.workflows.graph2
+
+corresponding to resource files like
+
+.. code-block:: text
+
+    myproject/module1/workflows/graph1.json
+    myproject/module2/workflows/graph2.yaml
+
+The wildcard `"*"` matches exactly one package or workflow name component.
+
+To discover all workflows provided by all installed python packages
+
+.. code-block:: python
+
+    from ewokscore.workflow_discovery import discover_all_workflows
+
+    workflows = discover_all_workflows(workflow_extension="yaml")
+
+For this to work the package that provides ewoks workflows should declare its workflow modules
+via the entry point mechanism.
+
+.. code-block:: toml
+
+    # pyproject.toml
+
+    [project.entry-points."ewoks.workflows"]
+    "myproject.workflows.*" = "myproject1"
+    "myproject.*.demo.*" = "myproject2"
+
+The group name must be `"ewoks.workflows"`.
+
+The keys are the module patterns in which to discover workflows. The values are ignored but need
+to be globally unique because of the way entry points work.
+
+The workflow discovery mechanism searches for workflow resource files inside python packages.
+For example, the entry point
+
+.. code-block:: toml
+
+    [project.entry-points."ewoks.workflows"]
+    "myproject.workflows.*" = "myproject1"
+
+can discover workflow resources such as
+
+.. code-block:: text
+
+    myproject/workflows/example.json
+    myproject/workflows/demo.yaml
+
+A project that provides ewoks workflows can also add the `"ewoks"` keyword to be discoverable in
+a package repository like PyPI:
+
+.. code-block:: toml
+
+    # pyproject.toml
+
+    [project]
+    name = "myproject"
+    keywords = ["ewoks"]

--- a/doc/howtoguides/workflow_discovery.rst
+++ b/doc/howtoguides/workflow_discovery.rst
@@ -1,7 +1,11 @@
 Workflow discovery
 ==================
 
-All ewoks workflows provided by one or more python modules can be discovered as follows
+How to discover workflows
+-------------------------
+
+All ewoks workflows provided by one or more python modules can be discovered
+as follows
 
 .. code-block:: python
 
@@ -53,8 +57,16 @@ To discover all workflows provided by all installed python packages
 
     workflows = discover_all_workflows(workflow_extension="yaml")
 
-For this to work the package that provides ewoks workflows should declare its workflow modules
-via the entry point mechanism.
+The workflow discovery mechanism searches for workflow resource files inside
+python packages.
+
+
+How to declare workflows to be discovered
+-----------------------------------------
+
+For automatic discovery to work across installed packages, a package that
+provides ewoks workflows should declare its workflow modules via the entry
+point mechanism.
 
 .. code-block:: toml
 
@@ -66,10 +78,12 @@ via the entry point mechanism.
 
 The group name must be `"ewoks.workflows"`.
 
-The keys are the module patterns in which to discover workflows. The values are ignored but typically the project
-name is used so the entry point can be loaded like any python entry point even though it is not used this way.
+The keys are the module patterns in which to discover workflows.
 
-The workflow discovery mechanism searches for workflow resource files inside python packages.
+The values are ignored but typically the project name is used so the entry
+point can be loaded like any python entry point even though it is not used
+this way.
+
 For example, the entry point
 
 .. code-block:: toml
@@ -77,15 +91,15 @@ For example, the entry point
     [project.entry-points."ewoks.workflows"]
     "myproject.workflows.*" = "myproject1"
 
-can discover workflow resources such as
+can declare workflow resources such as
 
 .. code-block:: text
 
     myproject/workflows/example.json
     myproject/workflows/demo.yaml
 
-A project that provides ewoks workflows can also add the `"ewoks"` keyword to be discoverable in
-a package repository like PyPI:
+A project that provides ewoks workflows can also add the `"ewoks"` keyword to
+be discoverable in a package repository like PyPI:
 
 .. code-block:: toml
 

--- a/src/ewokscore/task_discovery.py
+++ b/src/ewokscore/task_discovery.py
@@ -192,7 +192,6 @@ def _iter_discover_all_tasks(
     task_type: Optional[str] = None,
     raise_import_failure: bool = False,
 ) -> Generator[TaskDict, None, None]:
-    visited = set()
     if task_type is None:
         task_types = ("class", "ppfmethod", "method")
     else:
@@ -200,9 +199,10 @@ def _iter_discover_all_tasks(
 
     for task_type in task_types:
         group = "ewoks.tasks." + task_type
+        visited = set()
         for entrypoint in entry_points(group):
             module_pattern = entrypoint.name
-            if module_pattern is visited:
+            if module_pattern in visited:
                 continue
             visited.add(module_pattern)
             yield from discover_tasks_from_modules(
@@ -228,11 +228,14 @@ def discover_all_tasks(
 
 
 def _iter_modules_from_pattern(
-    module_pattern: str, reload: bool = False, raise_import_failure: bool = False
+    module_name_or_pattern: str,
+    reload: bool = False,
+    raise_import_failure: bool = False,
 ) -> Generator[str, None, None]:
-    if "*" not in module_pattern:
-        yield module_pattern
+    if "*" not in module_name_or_pattern:
+        yield module_name_or_pattern
         return
+    module_pattern = module_name_or_pattern
     ndots = module_pattern.count(".")
     parts = module_pattern.split(".")
     pkg = _safe_import_module(

--- a/src/ewokscore/tests/conftest.py
+++ b/src/ewokscore/tests/conftest.py
@@ -235,6 +235,18 @@ def expected_tasks(module=None, task_type=None):
     ]
 
 
+def expected_workflows(module=None, workflow_extension=None):
+    if module == "ewokscore.tests.examples.loadtest" and workflow_extension in (
+        "json",
+        None,
+    ):
+        return [
+            "ewokscore.tests.examples.loadtest.graph",
+            "ewokscore.tests.examples.loadtest.subgraph",
+        ]
+    return []
+
+
 @pytest.fixture()
 def engine():
     return CoreWorkflowEngine()

--- a/src/ewokscore/tests/test_workflow_discovery.py
+++ b/src/ewokscore/tests/test_workflow_discovery.py
@@ -1,0 +1,56 @@
+import pytest
+
+from .. import workflow_discovery
+from .conftest import expected_workflows
+
+
+@pytest.mark.parametrize("workflow_extension", ["json", "yaml", None])
+def test_discover_workflows_from_one_module(workflow_extension):
+    expected = expected_workflows(
+        "ewokscore.tests.examples.loadtest", workflow_extension
+    )
+
+    workflows = workflow_discovery.discover_workflows_from_package_data(
+        "ewokscore.tests.examples.loadtest.*", workflow_extension=workflow_extension
+    )
+    assert set(workflows) == set(expected)
+
+
+@pytest.mark.parametrize("workflow_extension", ["json", "yaml", None])
+def test_discover_workflows_from_module_pattern(workflow_extension):
+    expected = expected_workflows(
+        "ewokscore.tests.examples.loadtest", workflow_extension
+    )
+
+    workflows = workflow_discovery.discover_workflows_from_package_data(
+        "ewokscore.tests.ex*.loadtest.*", workflow_extension=workflow_extension
+    )
+    assert set(workflows) == set(expected)
+
+
+@pytest.mark.parametrize("workflow_extension", ["json", "yaml", None])
+def test_all_workflows_discovery(monkeypatch, workflow_extension):
+    expected = expected_workflows(
+        "ewokscore.tests.examples.loadtest", workflow_extension
+    )
+
+    monkeypatch.setattr(workflow_discovery, "entry_points", _mock_entry_points)
+
+    workflows = workflow_discovery.discover_all_workflows(
+        workflow_extension=workflow_extension
+    )
+
+    assert set(workflows) == set(expected)
+
+
+class _MockEntryPoint:
+    def __init__(self, name):
+        self.name = name
+
+
+def _mock_entry_points(group):
+    assert group == "ewoks.workflows"
+    return [
+        _MockEntryPoint("ewokscore.tests.examples.loadtest.*"),
+        _MockEntryPoint("ewokscore.tests.examples.loadtest.*"),
+    ]

--- a/src/ewokscore/workflow_discovery.py
+++ b/src/ewokscore/workflow_discovery.py
@@ -1,0 +1,152 @@
+import sys
+from fnmatch import fnmatch
+from typing import Generator
+from typing import List
+from typing import Optional
+
+if sys.version_info < (3, 9):
+    import importlib_resources
+else:
+    import importlib.resources as importlib_resources
+
+
+from .entry_points import entry_points
+
+
+def discover_all_workflows(
+    workflow_extension: Optional[str] = None,
+    raise_import_failure: bool = True,
+) -> List[str]:
+    """
+    Generates the full python qualifier names of the workflows
+    as defined by entry-point group "ewoks.workflows".
+    """
+    return list(
+        _iter_discover_all_workflows(
+            workflow_extension=workflow_extension,
+            raise_import_failure=raise_import_failure,
+        )
+    )
+
+
+def discover_workflows_from_package_data(
+    *fq_names_or_patterns: str,
+    workflow_extension: Optional[str] = None,
+    raise_import_failure: bool = True,
+) -> List[str]:
+    """
+    Generates the full python qualifier names of the workflows
+    as defined by the module names/patterns.
+    """
+    if workflow_extension is None:
+        workflow_extensions = ("json", "yaml")
+    else:
+        workflow_extensions = (workflow_extension,)
+
+    result = list()
+    for fq_name_or_pattern in fq_names_or_patterns:
+        for workflow_extension in workflow_extensions:
+            result.extend(
+                _iter_fqns_from_pattern(
+                    fq_name_or_pattern,
+                    file_extension=workflow_extension,
+                    raise_import_failure=raise_import_failure,
+                )
+            )
+    return result
+
+
+def _iter_discover_all_workflows(
+    workflow_extension: Optional[str] = None,
+    raise_import_failure: bool = True,
+) -> Generator[str, None, None]:
+    visited = set()
+    for entrypoint in entry_points("ewoks.workflows"):
+        module_pattern = entrypoint.name
+        if module_pattern in visited:
+            continue
+        visited.add(module_pattern)
+        yield from discover_workflows_from_package_data(
+            module_pattern,
+            workflow_extension=workflow_extension,
+            raise_import_failure=raise_import_failure,
+        )
+
+
+def _iter_fqns_from_pattern(
+    fq_name_or_pattern: str,
+    file_extension: str,
+    raise_import_failure: bool = True,
+) -> Generator[str, None, None]:
+    if not fq_name_or_pattern:
+        return
+
+    parts = fq_name_or_pattern.split(".")
+    first = parts[0]
+    rest = parts[1:]
+
+    yield from _iter_module_pattern_parts(
+        current_package=first,
+        remaining_parts=rest,
+        file_extension=file_extension,
+        raise_import_failure=raise_import_failure,
+    )
+
+
+def _iter_module_pattern_parts(
+    current_package: str,
+    remaining_parts: List[str],
+    file_extension: str,
+    raise_import_failure: bool = True,
+) -> Generator[str, None, None]:
+    if not remaining_parts:
+        return
+
+    part = remaining_parts[0]
+    tail = remaining_parts[1:]
+
+    try:
+        files = importlib_resources.files(current_package)
+    except Exception:
+        if raise_import_failure:
+            raise
+        return
+
+    # Last component: match workflow resource files
+    if not tail:
+        pattern = f"{part}.{file_extension}"
+
+        for resource in files.iterdir():
+            if not resource.is_file():
+                continue
+
+            if fnmatch(resource.name, pattern):
+                stem = resource.name[: -(len(file_extension) + 1)]
+                yield f"{current_package}.{stem}"
+
+        return
+
+    # Intermediate package matching
+    for resource in files.iterdir():
+        if not resource.is_dir():
+            continue
+
+        if not fnmatch(resource.name, part):
+            continue
+
+        subpackage = f"{current_package}.{resource.name}"
+
+        # Ensure it is importable as a package
+        try:
+            importlib_resources.files(subpackage)
+        except Exception:
+            if raise_import_failure:
+                raise
+            continue
+
+        yield from _iter_module_pattern_parts(
+            current_package=subpackage,
+            remaining_parts=tail,
+            file_extension=file_extension,
+            raise_import_failure=raise_import_failure,
+        )


### PR DESCRIPTION
Closes #436 

This is the second step in supporting non-editable workflows in ewoksserver. The workflows are part of python packages and can be discovered in a similar way than ewoks tasks.