### PR TITLE
fix[pydantic]: Manage pydantic `Field.deprecated` attribute

### DIFF
--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -160,7 +160,10 @@ class Task(Registered, UniversalHashable, register=False):
         model = self._INPUT_MODEL(**inputs)
 
         for name in self._INPUT_MODEL.model_fields.keys():
-            if self.__inputs[name].is_missing():
+            is_deprecated = self._INPUT_MODEL.model_fields[name].deprecated
+            not_supplied = self.__inputs[name].is_missing()
+
+            if is_deprecated and not_supplied:
                 with warnings.catch_warnings():
                     warnings.simplefilter("ignore", DeprecationWarning)
                     self.__inputs[name].value = getattr(model, name)

--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -3,6 +3,7 @@ import os
 import random
 import re
 import time
+import warnings
 from contextlib import ExitStack
 from contextlib import contextmanager
 from difflib import get_close_matches
@@ -159,7 +160,12 @@ class Task(Registered, UniversalHashable, register=False):
         model = self._INPUT_MODEL(**inputs)
 
         for name in self._INPUT_MODEL.model_fields.keys():
-            self.__inputs[name].value = getattr(model, name)
+            if self.__inputs[name].is_missing():
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", DeprecationWarning)
+                    self.__inputs[name].value = getattr(model, name)
+            else:
+                self.__inputs[name].value = getattr(model, name)
 
     def _validate_outputs(self) -> None:
         """Check outputs with accessing the output values.

--- a/src/ewokscore/tests/test_task_input_model.py
+++ b/src/ewokscore/tests/test_task_input_model.py
@@ -1,9 +1,12 @@
+import warnings
 from dataclasses import dataclass
 from typing import Union
 
 import pytest
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic import field_validator
+from typing_extensions import deprecated
 
 from ..missing_data import MISSING_DATA
 from ..missing_data import MissingData
@@ -307,3 +310,25 @@ def test_dataclass_field_stays_dataclass():
         inputs={"address": Address(city="Grenoble", street="Jean-Jaurès")}
     )
     task.execute()
+
+
+class DeprecatedInput(BaseInputModel):
+    a: int = Field(2, deprecated=deprecated("deprecated"))
+
+
+class MyTaskWithDeprecatedInput(Task, input_model=DeprecatedInput):
+    def run(self):
+        pass
+
+
+def test_no_deprecation_warning_when_deprecated_field_not_provided():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        task = MyTaskWithDeprecatedInput()
+        task.execute()
+
+
+def test_deprecation_warning_when_deprecated_field_is_used_in_task():
+    task = MyTaskWithDeprecatedInput(inputs={"a": 42})
+    with pytest.warns(DeprecationWarning):
+        task.execute()

--- a/src/ewokscore/tests/test_task_input_model.py
+++ b/src/ewokscore/tests/test_task_input_model.py
@@ -6,7 +6,6 @@ import pytest
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import field_validator
-from typing_extensions import deprecated
 
 from ..missing_data import MISSING_DATA
 from ..missing_data import MissingData
@@ -313,7 +312,7 @@ def test_dataclass_field_stays_dataclass():
 
 
 class DeprecatedInput(BaseInputModel):
-    a: int = Field(2, deprecated=deprecated("deprecated"))
+    a: int = Field(2, deprecated="deprecated")
 
 
 class MyTaskWithDeprecatedInput(Task, input_model=DeprecatedInput):


### PR DESCRIPTION
finally the simplest implementation was to ignore warning only if input is missing.

-> The input is not given by user : No warning

-> The input IS given by user : Deprecation Warning

Note : Default behavior in python is to ignore DeprecationWarning (except in main module). This default behaviour can be overrided (ie: python -W default)