### PR TITLE
fix task warnings and introduce TaskInputWarning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add workflow discovery from python package data files in analogy to task discovery.
   Full qualifier names or patterns can be added to the entry point group `"ewoks.workflows"`
   of any python project.
-- Emit a warning if a `Task` class instance received unknown inputs
+- Emit a `TaskInputWarning` if a `Task` class instance received unknown named inputs.
 
 ### Fixed
 

--- a/src/ewokscore/graph/graph_io.py
+++ b/src/ewokscore/graph/graph_io.py
@@ -74,7 +74,7 @@ def parse_inputs(
 
         if missing:
             error_report = (
-                f"\n Missing required keys {missing} in input item: {input_item}."
+                f"Missing required keys {missing} in input item: {input_item}."
                 + build_close_match_report(missing, input_item.keys())
             )
             raise ValueError(error_report)

--- a/src/ewokscore/methodtask.py
+++ b/src/ewokscore/methodtask.py
@@ -13,7 +13,7 @@ class MethodExecutorTask(
 ):
     METHOD_ARGUMENT = METHOD_ARGUMENT
 
-    def _warn_unexpected_inputs(self, input_names: Set[str]) -> None:
+    def _warn_unexpected_inputs(self, unexpected_names: Set[str]) -> None:
         pass
 
     def _get_task_identifier(self, inputs: Mapping) -> str:

--- a/src/ewokscore/notebooktask.py
+++ b/src/ewokscore/notebooktask.py
@@ -24,7 +24,7 @@ class NotebookExecutorTask(
 ):
     NOTEBOOK_ARGUMENT = NOTEBOOK_ARGUMENT
 
-    def _warn_unexpected_inputs(self, input_names: Set[str]) -> None:
+    def _warn_unexpected_inputs(self, unexpected_names: Set[str]) -> None:
         pass
 
     def run(self):

--- a/src/ewokscore/ppftasks.py
+++ b/src/ewokscore/ppftasks.py
@@ -23,7 +23,7 @@ class PpfMethodExecutorTask(
     METHOD_ARGUMENT = METHOD_ARGUMENT
     PPF_DICT_ARGUMENT = PPF_DICT_ARGUMENT
 
-    def _warn_unexpected_inputs(self, input_names: Set[str]) -> None:
+    def _warn_unexpected_inputs(self, unexpected_names: Set[str]) -> None:
         pass
 
     def _get_task_identifier(self, inputs: Mapping) -> str:

--- a/src/ewokscore/scripttask.py
+++ b/src/ewokscore/scripttask.py
@@ -92,7 +92,7 @@ class ScriptExecutorTask(
 
     SCRIPT_ARGUMENT = SCRIPT_ARGUMENT
 
-    def _warn_unexpected_inputs(self, input_names: Set[str]) -> None:
+    def _warn_unexpected_inputs(self, unexpected_names: Set[str]) -> None:
         pass
 
     def _get_task_identifier(self, inputs: Mapping) -> str:

--- a/src/ewokscore/task.py
+++ b/src/ewokscore/task.py
@@ -40,6 +40,10 @@ class TaskInputError(ValueError):
     pass
 
 
+class TaskInputWarning(UserWarning):
+    pass
+
+
 class Task(Registered, UniversalHashable, register=False):
     """Node in a task Graph with named inputs and outputs.
 
@@ -126,43 +130,49 @@ class Task(Registered, UniversalHashable, register=False):
         """Check inputs without accessing the input values.
         Persisted variables are not loaded.
         """
-        input_names = set(inputs.keys())
-        required_and_optional_inputs = (
-            self.required_input_names() | self.optional_input_names()
-        )
-        non_existing_inputs = input_names - required_and_optional_inputs
+        input_keys = set(inputs.keys())
+        input_names = {
+            key for key in input_keys if isinstance(key, str) and not key.isdigit()
+        }
 
-        # Check required inputs
-        missing_required = self.required_input_names() - input_names
-        if missing_required:
+        # Warn about unexpected named inputs
+        expected_names = self.required_input_names() | self.optional_input_names()
+        unexpected_names = input_names - expected_names
+        if unexpected_names:
+            self._warn_unexpected_inputs(unexpected_names)
+
+        # Warn about potential typo's in named optional inputs
+        missing_optional_names = self.optional_input_names() - input_names
+        if missing_optional_names:
             error_report = build_close_match_report(
-                missing_required, non_existing_inputs
+                missing_optional_names, unexpected_names
+            )
+            if error_report:
+                logger.warning("Possible missing optional inputs:%s", error_report)
+
+        # Raise error when required named inputs are missing
+        missing_required_names = self.required_input_names() - input_names
+        if missing_required_names:
+            error_report = build_close_match_report(
+                missing_required_names, unexpected_names
             )
             self._raise_task_input_error(
-                "Missing inputs", str(list(missing_required)) + error_report
+                "Missing inputs", str(list(missing_required_names)) + error_report
             )
 
-        # Check required positional inputs
-        nrequiredargs = self._N_REQUIRED_POSITIONAL_INPUTS
-        for i in range(nrequiredargs):
-            if i not in inputs and str(i) not in inputs:
+        # Raise error when required positional inputs are missing
+        for i in range(self._N_REQUIRED_POSITIONAL_INPUTS):
+            if i not in input_keys and str(i) not in input_keys:
                 self._raise_task_input_error(
                     "Missing inputs", f"positional argument #{i}"
                 )
 
-        self._warn_unexpected_inputs(input_names)
-
-        # Init missing optional inputs
-        missing_optional = self.optional_input_names() - input_names
-        if missing_optional:
-            error_report = build_close_match_report(
-                missing_optional, non_existing_inputs
-            )
-            if error_report:
-                logger.warning("\n Possible missing optional inputs:" + error_report)
+        # Initialize missing optional inputs
+        if missing_optional_names:
             inputs = dict(inputs)
-            for varname in missing_optional:
+            for varname in missing_optional_names:
                 inputs[varname] = self.MISSING_DATA
+
         return inputs
 
     def _validate_inputs(self) -> None:
@@ -697,21 +707,11 @@ class Task(Registered, UniversalHashable, register=False):
             err_msg = f"{prefix} for ewoks task (id: {node_id!r}, task: {task_identifier!r}): {message}"
         raise exc_class(err_msg) from cause
 
-    def _warn_unexpected_inputs(self, input_names: Set[str]) -> None:
-        extra_inputs = input_names - self.input_names()
-
-        # if input is positional argument
-        unexpected_named_inputs = {
-            name for name in extra_inputs if not isinstance(name, int)
-        }
-
-        if not unexpected_named_inputs:
-            return
-
+    def _warn_unexpected_inputs(self, unexpected_names: Set[str]) -> None:
         warnings.warn(
             f"Unexpected inputs for task {type(self).__name__}: "
-            f"{sorted(unexpected_named_inputs)}",
-            UserWarning,
+            f"{sorted(unexpected_names)}",
+            TaskInputWarning,
             stacklevel=3,
         )
 

--- a/src/ewokscore/tests/test_closematch.py
+++ b/src/ewokscore/tests/test_closematch.py
@@ -1,6 +1,9 @@
+import re
+
 import pytest
 
-from ewokscore import execute_graph
+from ..bindings import execute_graph
+from ..task import TaskInputWarning
 
 
 def test_matcher_input_typo():
@@ -34,53 +37,61 @@ def test_matcher_typo_required_inputs():
         ValueError,
         match="You provided 'listx'. Did you mean 'list'?",
     ):
-        _ = execute_graph(
-            graph={
-                "graph": {"id": "test"},
-                "nodes": [
+        with pytest.warns(
+            TaskInputWarning,
+            match=re.escape("Unexpected inputs for task SumList: ['listx']"),
+        ):
+            _ = execute_graph(
+                graph={
+                    "graph": {"id": "test"},
+                    "nodes": [
+                        {
+                            "id": "sumlist1",
+                            "task_type": "class",
+                            "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
+                        }
+                    ],
+                },
+                inputs=[
                     {
                         "id": "sumlist1",
-                        "task_type": "class",
-                        "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
-                    }
+                        "name": "listx",
+                        "value": [1, 2, 3],
+                    },
                 ],
-            },
-            inputs=[
-                {
-                    "id": "sumlist1",
-                    "name": "listx",
-                    "value": [1, 2, 3],
-                },
-            ],
-        )
+            )
 
 
 def test_matcher_typo_optional_inputs(caplog):
     with caplog.at_level("WARNING", logger="ewokscore.task"):
-        _ = execute_graph(
-            graph={
-                "graph": {"id": "test"},
-                "nodes": [
+        with pytest.warns(
+            TaskInputWarning,
+            match=re.escape("Unexpected inputs for task SumList: ['delayx']"),
+        ):
+            _ = execute_graph(
+                graph={
+                    "graph": {"id": "test"},
+                    "nodes": [
+                        {
+                            "id": "sumlist1",
+                            "task_type": "class",
+                            "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
+                        }
+                    ],
+                },
+                inputs=[
                     {
                         "id": "sumlist1",
-                        "task_type": "class",
-                        "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
-                    }
+                        "name": "list",
+                        "value": [1, 2, 3],
+                    },
+                    {
+                        "id": "sumlist1",
+                        "name": "delayx",
+                        "value": 1,
+                    },
                 ],
-            },
-            inputs=[
-                {
-                    "id": "sumlist1",
-                    "name": "list",
-                    "value": [1, 2, 3],
-                },
-                {
-                    "id": "sumlist1",
-                    "name": "delayx",
-                    "value": 1,
-                },
-            ],
-        )
+            )
     assert "You provided 'delayx'. Did you mean 'delay'?" in caplog.text
 
 
@@ -89,48 +100,56 @@ def test_matcher_typo_required_default_inputs():
         ValueError,
         match="You provided 'listx'. Did you mean 'list'?",
     ):
-        _ = execute_graph(
-            graph={
-                "graph": {"id": "test"},
-                "nodes": [
-                    {
-                        "id": "sumlist1",
-                        "task_type": "class",
-                        "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
-                        "default_inputs": [
-                            {
-                                "name": "listx",
-                                "value": [1, 2, 3],
-                            },
-                        ],
-                    }
-                ],
-            },
-        )
+        with pytest.warns(
+            TaskInputWarning,
+            match=re.escape("Unexpected inputs for task SumList: ['listx']"),
+        ):
+            _ = execute_graph(
+                graph={
+                    "graph": {"id": "test"},
+                    "nodes": [
+                        {
+                            "id": "sumlist1",
+                            "task_type": "class",
+                            "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
+                            "default_inputs": [
+                                {
+                                    "name": "listx",
+                                    "value": [1, 2, 3],
+                                },
+                            ],
+                        }
+                    ],
+                },
+            )
 
 
 def test_matcher_typo_optional_default_inputs(caplog):
     with caplog.at_level("WARNING", logger="ewokscore.task"):
-        _ = execute_graph(
-            graph={
-                "graph": {"id": "test"},
-                "nodes": [
-                    {
-                        "id": "sumlist1",
-                        "task_type": "class",
-                        "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
-                        "default_inputs": [
-                            {
-                                "name": "list",
-                                "value": [1, 2, 3],
-                            },
-                            {
-                                "name": "delayx",
-                                "value": 1,
-                            },
-                        ],
-                    }
-                ],
-            },
-        )
+        with pytest.warns(
+            TaskInputWarning,
+            match=re.escape("Unexpected inputs for task SumList: ['delayx']"),
+        ):
+            _ = execute_graph(
+                graph={
+                    "graph": {"id": "test"},
+                    "nodes": [
+                        {
+                            "id": "sumlist1",
+                            "task_type": "class",
+                            "task_identifier": "ewokscore.tests.examples.tasks.sumlist.SumList",
+                            "default_inputs": [
+                                {
+                                    "name": "list",
+                                    "value": [1, 2, 3],
+                                },
+                                {
+                                    "name": "delayx",
+                                    "value": 1,
+                                },
+                            ],
+                        }
+                    ],
+                },
+            )
     assert "You provided 'delayx'. Did you mean 'delay'?" in caplog.text

--- a/src/ewokscore/tests/test_script_task.py
+++ b/src/ewokscore/tests/test_script_task.py
@@ -143,7 +143,7 @@ def test_command_task(tmp_path, varinfo):
     task = Task.instantiate(
         "ScriptExecutorTask",
         inputs={
-            0: str(tmp_path),
+            "0": str(tmp_path),
             "_script": "dir",
             "_capture_output": True,
             "_raise_on_error": False,

--- a/src/ewokscore/tests/test_task.py
+++ b/src/ewokscore/tests/test_task.py
@@ -9,6 +9,7 @@ import pytest
 
 from ..task import Task
 from ..task import TaskInputError
+from ..task import TaskInputWarning
 from .examples.tasks.sumtask import SumTask
 
 
@@ -47,7 +48,7 @@ def test_task_missing_input():
 
 def test_task_unexpected_input_warning():
     with pytest.warns(
-        UserWarning,
+        TaskInputWarning,
         match=re.escape("Unexpected inputs for task SumTask: ['unknown']"),
     ):
         task = SumTask(inputs={"a": 10, "unknown": 1})


### PR DESCRIPTION
In this PR

- fix the collisions between 
  - https://github.com/ewoks-kit/ewokscore/pull/455
  - https://github.com/ewoks-kit/ewokscore/pull/453
  - https://github.com/ewoks-kit/ewokscore/pull/452
- introduce `TaskInputWarning`
- adapt the CI

Note: inputs can be named or positional. When positional it can be `0` (int) or `"0"` (str).