### PR TITLE
rename discover_workflows_from_package_data to discover_tasks_from_modules in analogy to discover_tasks_from_modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support for Graph serialization and transparent handling of `Numpy arrays` in both JSON and 
   YAML via pickling.
-- Add workflow discovery from python package data files in analogy to task discovery.
+- Add workflow discovery from python modules in analogy to task discovery from python modules.
   Full qualifier names or patterns can be added to the entry point group `"ewoks.workflows"`
   of any python project.
 - Emit a `TaskInputWarning` if a `Task` class instance received unknown named inputs.

--- a/src/ewokscore/tests/test_workflow_discovery.py
+++ b/src/ewokscore/tests/test_workflow_discovery.py
@@ -10,7 +10,7 @@ def test_discover_workflows_from_one_module(workflow_extension):
         "ewokscore.tests.examples.loadtest", workflow_extension
     )
 
-    workflows = workflow_discovery.discover_workflows_from_package_data(
+    workflows = workflow_discovery.discover_tasks_from_modules(
         "ewokscore.tests.examples.loadtest.*", workflow_extension=workflow_extension
     )
     assert set(workflows) == set(expected)
@@ -22,7 +22,7 @@ def test_discover_workflows_from_module_pattern(workflow_extension):
         "ewokscore.tests.examples.loadtest", workflow_extension
     )
 
-    workflows = workflow_discovery.discover_workflows_from_package_data(
+    workflows = workflow_discovery.discover_tasks_from_modules(
         "ewokscore.tests.ex*.loadtest.*", workflow_extension=workflow_extension
     )
     assert set(workflows) == set(expected)

--- a/src/ewokscore/workflow_discovery.py
+++ b/src/ewokscore/workflow_discovery.py
@@ -29,7 +29,7 @@ def discover_all_workflows(
     )
 
 
-def discover_workflows_from_package_data(
+def discover_tasks_from_modules(
     *fq_names_or_patterns: str,
     workflow_extension: Optional[str] = None,
     raise_import_failure: bool = True,
@@ -66,7 +66,7 @@ def _iter_discover_all_workflows(
         if module_pattern in visited:
             continue
         visited.add(module_pattern)
-        yield from discover_workflows_from_package_data(
+        yield from discover_tasks_from_modules(
             module_pattern,
             workflow_extension=workflow_extension,
             raise_import_failure=raise_import_failure,


### PR DESCRIPTION
Fix https://github.com/ewoks-kit/ewokscore/pull/450: docs are correct but code is not.