### PR TITLE
Fix scripts not appearing in the doc

### DIFF
--- a/doc/tutorials/hello_world.rst
+++ b/doc/tutorials/hello_world.rst
@@ -3,6 +3,6 @@ Hello world
 
 A short script that defines a task, creates a workflow and executes it.
 
-.. literalinclude:: examples/hello_world.py
+.. literalinclude:: /examples/hello_world.py
    :language: python
    :caption: hello_world.py

--- a/doc/tutorials/hello_world_validation.rst
+++ b/doc/tutorials/hello_world_validation.rst
@@ -3,6 +3,6 @@ Hello world with validation
 
 A short script that defines a task with input and output validation, creates a workflow and executes it.
 
-.. literalinclude:: examples/hello_world_validation.py
+.. literalinclude:: /examples/hello_world_validation.py
    :language: python
    :caption: hello_world_validation.py


### PR DESCRIPTION
Since Sphinx 9.0, the way `literalinclude` paths are resolved seem to have changed. I didn't see any mention of this in the release notes though (https://www.sphinx-doc.org/en/master/changes/9.0.html#release-9-0-4-released-dec-04-2025)

Anyway, it means that the paths are not correctly resolved so that the `literalinclude` does not show anything.

In this PR, I changed the path to be absolute with respect to the source folder: https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude