### PR TITLE
Speed-up connect_default_error_handlers

### DIFF
--- a/src/ewokscore/graph/error_handlers.py
+++ b/src/ewokscore/graph/error_handlers.py
@@ -1,12 +1,13 @@
 from typing import Mapping
+from typing import Set
 
 import networkx
 
-from .analysis import node_ancestors
+from ..node import NodeIdType
 from .analysis import node_pure_descendants
 
 
-def connect_default_error_handlers(graph: networkx.DiGraph) -> networkx.DiGraph:
+def connect_default_error_handlers(graph: networkx.DiGraph) -> None:
     """All nodes without an error handler will be connected to all default error handlers.
     Default error handlers without predecessors will be removed.
     """
@@ -39,11 +40,8 @@ def connect_default_error_handlers(graph: networkx.DiGraph) -> networkx.DiGraph:
                 nodes_without_error_handlers.remove(source_id)
 
     # Remove nodes that have any of the default error handlers as ancestor
-    for node_id in set(nodes_without_error_handlers):
-        for ancestor_id in node_ancestors(graph, node_id):
-            if ancestor_id in default_error_handlers:
-                nodes_without_error_handlers.remove(node_id)
-                break
+    if default_error_handlers:
+        nodes_without_error_handlers -= _descendants(graph, set(default_error_handlers))
 
     if nodes_without_error_handlers:
         # Connect to the default error handlers
@@ -60,3 +58,16 @@ def connect_default_error_handlers(graph: networkx.DiGraph) -> networkx.DiGraph:
                 # Default error handler has not predecessors
                 nodes = set(node_pure_descendants(graph, node_id, include_node=True))
                 graph.remove_nodes_from(nodes)
+
+
+def _descendants(graph: networkx.DiGraph, node_ids: Set[NodeIdType]) -> Set[NodeIdType]:
+    """All descendants of any node in `node_ids`."""
+    visited: Set[NodeIdType] = set()
+    stack = list(node_ids)
+    while stack:
+        node_id = stack.pop()
+        for target_id in graph.successors(node_id):
+            if target_id not in visited:
+                visited.add(target_id)
+                stack.append(target_id)
+    return visited


### PR DESCRIPTION
Quick win for MX workflows before refactoring the graph analysis: https://github.com/ewoks-kit/ewokscore/issues/40#issuecomment-5195530755

```python
import time

from ewoks import load_graph
from ewoksppf.bindings import EwoksWorkflow

t0 = time.perf_counter()

ewoksgraph = load_graph("MXPressE", root_module="bes.flows")

t1 = time.perf_counter()

workflow = EwoksWorkflow(ewoksgraph)

t2 = time.perf_counter()

print("Ewoks:", t1 - t0)
print("Ppf:", t2 - t1)
```

Before this PR:

```
Ewoks: 2.6934584959999484
Ppf: 0.043437874999654014
```

After this PR:

```
Ewoks: 0.3990270340000279
Ppf: 0.04421490299864672
```

This quick win is useful when switching from BES flask servers to Ewoks workers. The BES flask server is caching the result of `load_graph()` with a wapper called `load_workflow()`

```python
import time
import tempfile


from bes.job_manager.workflow_utils import load_workflow, parse_workflow_name

with tempfile.TemporaryDirectory() as tmpdirname:

    t0 = time.perf_counter()

    _, path = parse_workflow_name("MXPressE")
    load_workflow(path, cache_directory=tmpdirname)

    t1 = time.perf_counter()

    load_workflow(path, cache_directory=tmpdirname)

    t2 = time.perf_counter()

    print("First:", t1 - t0)
    print("Second:", t2 - t1)
```

Before this PR:

```
First: 2.5053138860002946
Second: 0.0052449080012593186
```

After this PR:

```
First: 0.26184313200064935
Second: 0.005358114998671226
```

So caching gains ~0.3 sec on my PC after this fix. Hardly worth it as opposed to the original 2.5 sec which is significant.

Ping @olofsvensson @LudoBroche 
